### PR TITLE
Prep initial charts indexing

### DIFF
--- a/charts/prometheus-adapter/Chart.yaml
+++ b/charts/prometheus-adapter/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus-adapter
-version: 2.5.0
+version: 2.5.1
 appVersion: v0.7.0
 description: A Helm chart for k8s prometheus adapter
 home: https://github.com/DirectXMan12/k8s-prometheus-adapter

--- a/charts/prometheus-adapter/OWNERS
+++ b/charts/prometheus-adapter/OWNERS
@@ -1,8 +1,0 @@
-approvers:
-  - mattiasgees
-  - steven-sheehy
-  - hectorj2f
-reviewers:
-  - mattiasgees
-  - steven-sheehy
-  - hectorj2f

--- a/charts/prometheus-adapter/README.md
+++ b/charts/prometheus-adapter/README.md
@@ -6,21 +6,74 @@ Installs the [Prometheus Adapter](https://github.com/DirectXMan12/k8s-prometheus
 
 Kubernetes 1.14+
 
-## Installing the Chart
-
-To install the chart with the release name `my-release`:
+## Get Repo Info
 
 ```console
-$ helm install --name my-release stable/prometheus-adapter
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo update
 ```
 
-This command deploys the prometheus adapter with the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-## Using the Chart
+## Install Chart
+
+```console
+# Helm 3
+$ helm install [RELEASE_NAME] prometheus-community/prometheus-adapter
+
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-adapter
+```
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+# Helm 2
+$ helm inspect values prometheus-community/prometheus
+
+# Helm 3
+$ helm show values prometheus-community/prometheus
+```
+
+### Prometheus Service Endpoint
 
 To use the chart, ensure the `prometheus.url` and `prometheus.port` are configured with the correct Prometheus service endpoint. If Prometheus is exposed under HTTPS the host's CA Bundle must be exposed to the container using `extraVolumes` and `extraVolumeMounts`.
 
+### Adapter Rules
+
 Additionally, the chart comes with a set of default rules out of the box but they may pull in too many metrics or not map them correctly for your needs. Therefore, it is recommended to populate `rules.custom` with a list of rules (see the [config document](https://github.com/DirectXMan12/k8s-prometheus-adapter/blob/master/docs/config.md) for the proper format).
+
+### Horizontal Pod Autoscaler Metrics
 
 Finally, to configure your Horizontal Pod Autoscaler to use the custom metric, see the custom metrics section of the [HPA walkthrough](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/#autoscaling-on-multiple-metrics-and-custom-metrics).
 
@@ -30,7 +83,7 @@ The Prometheus Adapter can serve three different [metrics APIs](https://kubernet
 
 Enabling this option will cause custom metrics to be served at `/apis/custom.metrics.k8s.io/v1beta1`. Enabled by default when `rules.default` is true, but can be customized by populating `rules.custom`:
 
-```
+```yaml
 rules:
   custom:
   - seriesQuery: '{__name__=~"^some_metric_count$"}'
@@ -46,7 +99,7 @@ rules:
 
 Enabling this option will cause external metrics to be served at `/apis/external.metrics.k8s.io/v1beta1`. Can be enabled by populating `rules.external`:
 
-```
+```yaml
 rules:
   external:
   - seriesQuery: '{__name__=~"^some_metric_count$"}'
@@ -62,7 +115,7 @@ rules:
 
 Enabling this option will cause resource metrics to be served at `/apis/metrics.k8s.io/v1beta1`. Resource metrics will allow pod CPU and Memory metrics to be used in [Horizontal Pod Autoscalers](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) as well as the `kubectl top` command. Can be enabled by populating `rules.resource`:
 
-```
+```yaml
 rules:
   resource:
     cpu:
@@ -93,68 +146,3 @@ rules:
 ```
 
 **NOTE:** Setting a value for `rules.resource` will also deploy the resource metrics API service, providing the same functionality as [metrics-server](https://github.com/helm/charts/tree/master/stable/metrics-server). As such it is not possible to deploy them both in the same cluster.
-
-## Uninstalling the Chart
-
-To uninstall/delete the `my-release` deployment:
-
-```console
-$ helm delete my-release
-```
-
-The command removes all the Kubernetes components associated with the chart and deletes the release.
-
-## Configuration
-
-The following table lists the configurable parameters of the Prometheus Adapter chart and their default values.
-
-| Parameter                       | Description                                                                     | Default                                     |
-| ------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------|
-| `affinity`                      | Node affinity                                                                   | `{}`                                        |
-| `image.repository`              | Image repository                                                                | `directxman12/k8s-prometheus-adapter-amd64` |
-| `image.tag`                     | Image tag                                                                       | `v0.7.0`                                    |
-| `image.pullPolicy`              | Image pull policy                                                               | `IfNotPresent`                              |
-| `image.pullSecrets`             | Image pull secrets                                                              | `{}`                                        |
-| `logLevel`                      | Log level                                                                       | `4`                                         |
-| `listenPort`                    | Port that application would listen on in the container                          | `6443`                                      |
-| `metricsRelistInterval`         | Interval at which to re-list the set of all available metrics from Prometheus   | `1m`                                        |
-| `nodeSelector`                  | Node labels for pod assignment                                                  | `{}`                                        |
-| `podLabels`                     | Labels to add to the pod                                                        | `{}`                                        |
-| `podAnnotations`                | Annotations to add to the pod                                                   | `{}`                                        |
-| `priorityClassName`             | Pod priority                                                                    | ``                                          |
-| `prometheus.url`                | Url of where we can find the Prometheus service                                 | `http://prometheus.default.svc`             |
-| `prometheus.port`               | Port of where we can find the Prometheus service, zero to omit this option      | `9090`                                      |
-| `prometheus.path`               | Custom path to append to the prometheus URL                                     | ``                                          |
-| `rbac.create`                   | If true, create & use RBAC resources                                            | `true`                                      |
-| `resources`                     | CPU/Memory resource requests/limits                                             | `{}`                                        |
-| `rules.default`                 | If `true`, enable a set of default rules in the configmap                       | `true`                                      |
-| `rules.custom`                  | A list of custom configmap rules                                                | `[]`                                        |
-| `rules.existing`                | The name of an existing configMap with rules. Overrides default, custom and external. | ``                                    |
-| `rules.external`                | A list of custom rules for external metrics API                                 | `[]`                                        |
-| `rules.resource`                | `resourceRules` to set in configmap rules                                       | `{}`                                        |
-| `service.annotations`           | Annotations to add to the service                                               | `{}`                                        |
-| `service.port`                  | Service port to expose                                                          | `443`                                       |
-| `service.type`                  | Type of service to create                                                       | `ClusterIP`                                 |
-| `serviceAccount.create`         | If true, create & use Serviceaccount                                            | `true`                                      |
-| `serviceAccount.name`           | If not set and create is true, a name is generated using the fullname template  | ``                                          |
-| `tls.enable`                    | If true, use the provided certificates. If false, generate self-signed certs    | `false`                                     |
-| `tls.ca`                        | Public CA file that signed the APIService (ignored if tls.enable=false)         | ``                                          |
-| `tls.key`                       | Private key of the APIService (ignored if tls.enable=false)                     | ``                                          |
-| `tls.certificate`               | Public key of the APIService (ignored if tls.enable=false)                      | ``                                          |
-| `extraVolumeMounts`             | Any extra volumes mounts                                                        | `[]`                                        |
-| `extraVolumes`                  | Any extra volumes                                                               | `[]`                                        |
-| `tolerations`                   | List of node taints to tolerate                                                 | `[]`                                        |
-
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
-
-```console
-$ helm install --name my-release \
-  --set logLevel=1 \
- stable/prometheus-adapter
-```
-
-Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
-
-```console
-$ helm install --name my-release -f values.yaml stable/prometheus-adapter
-```

--- a/charts/prometheus-adapter/README.md
+++ b/charts/prometheus-adapter/README.md
@@ -10,7 +10,6 @@ Kubernetes 1.14+
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo update
 ```
 

--- a/charts/prometheus-adapter/README.md
+++ b/charts/prometheus-adapter/README.md
@@ -59,10 +59,10 @@ See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_h
 
 ```console
 # Helm 2
-$ helm inspect values prometheus-community/prometheus
+$ helm inspect values prometheus-community/prometheus-adapter
 
 # Helm 3
-$ helm show values prometheus-community/prometheus
+$ helm show values prometheus-community/prometheus-adapter
 ```
 
 ### Prometheus Service Endpoint

--- a/charts/prometheus-blackbox-exporter/Chart.yaml
+++ b/charts/prometheus-blackbox-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus Blackbox Exporter
 name: prometheus-blackbox-exporter
-version: 4.3.0
+version: 4.3.1
 appVersion: 0.16.0
 home: https://github.com/prometheus/blackbox_exporter
 sources:

--- a/charts/prometheus-blackbox-exporter/OWNERS
+++ b/charts/prometheus-blackbox-exporter/OWNERS
@@ -1,6 +1,0 @@
-approvers:
-- desaintmartin
-- gianrubio
-reviewers:
-- desaintmartin
-- gianrubio

--- a/charts/prometheus-blackbox-exporter/README.md
+++ b/charts/prometheus-blackbox-exporter/README.md
@@ -14,7 +14,6 @@ This chart creates a Blackbox-Exporter deployment on a [Kubernetes](http://kuber
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo update
 ```
 

--- a/charts/prometheus-blackbox-exporter/README.md
+++ b/charts/prometheus-blackbox-exporter/README.md
@@ -4,141 +4,94 @@ Prometheus exporter for blackbox testing
 
 Learn more: [https://github.com/prometheus/blackbox_exporter](https://github.com/prometheus/blackbox_exporter)
 
-## TL;DR;
-
-```bash
-$ helm install stable/prometheus-blackbox-exporter
-```
-
-## Introduction
-
 This chart creates a Blackbox-Exporter deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
 - Kubernetes 1.8+ with Beta APIs enabled
 
-## Installing the Chart
+## Get Repo Info
 
-To install the chart with the release name `my-release`:
-
-```bash
-$ helm install --name my-release stable/prometheus-blackbox-exporter
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo update
 ```
 
-The command deploys Blackbox Exporter on the Kubernetes cluster using the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-## Uninstalling the Chart
+## Install Chart
 
-To uninstall/delete the `my-release` deployment:
+```console
+# Helm 3
+$ helm install [RELEASE_NAME] prometheus-community/prometheus-blackbox-exporter
 
-```bash
-$ helm delete --purge my-release
-```
-The command removes all the Kubernetes components associated with the chart and deletes the release.
-
-## Configuration
-
-The following table lists the configurable parameters of the Blackbox-Exporter chart and their default values.
-
-| Parameter                                 | Description                                                                      | Default                                                                      |
-| ----------------------------------------- | -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
-| `kind`                                    | You can choose between `Deployment` or `DaemonSet`                               | `Deployment`                                                                 |
-| `config`                                  | Prometheus blackbox configuration                                                | {}                                                                           |
-| `secretConfig`                            | Whether to treat blackbox configuration as secret                                | `false`                                                                      |
-| `extraArgs`                               | Optional flags for blackbox                                                      | `[]`                                                                         |
-| `image.repository`                        | container image repository                                                       | `prom/blackbox-exporter`                                                     |
-| `image.tag`                               | container image tag                                                              | `v0.15.1`                                                                    |
-| `image.pullPolicy`                        | container image pull policy                                                      | `IfNotPresent`                                                               |
-| `image.pullSecrets`                       | container image pull secrets                                                     | `[]`                                                                         |
-| `ingress.annotations`                     | Ingress annotations                                                              | None                                                                         |
-| `ingress.enabled`                         | Enables Ingress                                                                  | `false`                                                                      |
-| `ingress.hosts`                           | Ingress accepted hostnames                                                       | None                                                                         |
-| `ingress.path`                            | Ingress accepted path                                                            | `/`                                                                         |
-| `ingress.tls`                             | Ingress TLS configuration                                                        | None                                                                         |
-| `nodeSelector`                            | node labels for pod assignment                                                   | `{}`                                                                         |
-| `runAsUser`                               | User to run blackbox-exporter container as                                       | `1000`                                                                       |
-| `readOnlyRootFilesystem`                  | Set blackbox-exporter file-system to read-only                                   | `true`                                                                       |
-| `runAsNonRoot`                            | Run blackbox-exporter as non-root                                                | `true`                                                                       |
-| `tolerations`                             | node tolerations for pod assignment                                              | `[]`                                                                         |
-| `affinity`                                | node affinity for pod assignment                                                 | `{}`                                                                         |
-| `podAnnotations`                          | annotations to add to each pod                                                   | `{}`                                                                         |
-| `podDisruptionBudget`                     | pod disruption budget                                                            | `{}`                                                                         |
-| `pspEnabled`                              | create pod security policy resources                                             | `true`                                                                       |
-| `priorityClassName`                       | priority class name                                                              | None                                                                         |
-| `allowIcmp`                               | whether to enable ICMP probes, by giving the pods `CAP_NET_RAW` and running as root | `false`                                                                   |
-| `resources`                               | pod resource requests & limits                                                   | `{}`                                                                         |
-| `restartPolicy`                           | container restart policy                                                         | `Always`                                                                     |
-| `livenessProbe`                           | Container liveness probe                                                         | See values.yaml                                                              |
-| `readinessProbe`                          | Container readiness probe                                                        | See values.yaml                                                              |
-| `networkPolicy.enabled`                   | Enable network policy and allow access from anywhere                             | `false`                                                                      |
-| `networkPolicy.allowMonitoringNamespace`  | Limit access only from monitoring namespace                                      | `false`                                                                      |
-| `service.annotations`                     | annotations for the service                                                      | `{}`                                                                         |
-| `service.labels`                          | additional labels for the service                                                | None                                                                         |
-| `service.type`                            | type of service to create                                                        | `ClusterIP`                                                                  |
-| `service.port`                            | port for the blackbox http service                                               | `9115`                                                                       |
-| `service.externalIPs`                     | list of external ips                                                             | []                                                                           |
-| `serviceAccount.create`                   | Specifies whether a service account should be created.                           | `true`                                                                       |
-| `serviceAccount.name`                     | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                 |
-| `serviceAccount.annotations`              | ServiceAccount annotations                                                       |                                                                              |
-| `serviceMonitor.enabled`                  | If true, a ServiceMonitor CRD is created for a prometheus operator               | `false`                                                                      |
-| `serviceMonitor.defaults.labels`          | Labels for prometheus operator                                                   | `{}`                                                                         |
-| `serviceMonitor.defaults.interval`        | Interval for prometheus operator endpoint                                        | `30s`                                                                        |
-| `serviceMonitor.defaults.scrapeTimeout`   | Scrape timeout for prometheus operator endpoint                                  | `30s`                                                                        |
-| `serviceMonitor.defaults.module`          | The module that blackbox will use if serviceMonitor is enabled                   | `http_2xx`                                                                   |
-| `serviceMonitor.targets.[]`               | List of targets to scrape                                                        | `[]`                                                                         |
-| `serviceMonitor.targets.[].name`          | Human readable name for the job. It will also appear in job labels in Prometheus | `example`                                                                    |
-| `serviceMonitor.targets.[].url`           | The URL that blackbox will scrape if serviceMonitor is enabled                   | `http://example.com/healthz`                                                 |
-| `serviceMonitor.targets.[].labels`        | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.labels }`                                        |
-| `serviceMonitor.targets.[].interval`      | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.interval }}`                                     |
-| `serviceMonitor.targets.[].scrapeTimeout` | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.scrateTimeout }}`                                |
-| `serviceMonitor.targets.[].module`        | See above in `serviceMonitor.defaults`                                           | `{{ serviceMonitor.defaults.module }}`                                       |
-| `prometheusRule.enabled`                  | Set this to true to create PrometheusRule for Prometheus operator | `false`     |
-| `prometheusRule.additionalLabels`         | Additional labels that can be passed to PrometheusRule | `{}`  |
-| `prometheusRule.namespace`                | Namespace where PrometheusRule resource should be created |      |
-| `prometheusRule.rules`                    | [PrometheusRule](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) to be created                      | `[]`                                                    |
-| `strategy`                                | strategy used to replace old Pods with new ones                                  | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":0},"type":"RollingUpdate"}` |
-
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
-
-```bash
-$ helm install --name my-release \
-    --set key_1=value_1,key_2=value_2 \
-    stable/prometheus-blackbox-exporter
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-blackbox-exporter
 ```
 
-Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+_See [configuration](#configuration) below._
 
-```bash
-# example for staging
-$ helm install --name my-release -f values.yaml stable/prometheus-blackbox-exporter
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
 ```
 
-> **Tip**: You can use the default [values.yaml](values.yaml)
+This removes all the Kubernetes components associated with the chart and deletes the release.
 
-## Upgrading an existing Release to a new major version
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-### 4.0.0
+## Upgrading Chart
+
+```console
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+### To 4.0.0
 
 This version create the service account by default and introduce pod security policy, it can be enabled by setting `pspEnabled: true`.
 
-### 2.0.0
+### To 2.0.0
 
 This version removes the `podDisruptionBudget.enabled` parameter and changes the default value of `podDisruptionBudget` to `{}`, in order to fix Helm 3 compatibility.
 
 In order to upgrade, please remove `podDisruptionBudget.enabled` from your custom values.yaml file and set the content of `podDisruptionBudget`, for example:
+
 ```yaml
 podDisruptionBudget:
   maxUnavailable: 0
 ```
 
-### 1.0.0
+### To 1.0.0
 
 This version introduce the new recommended labels.
 
 In order to upgrade, delete the Deployment before upgrading:
+
 ```bash
-$ kubectl delete deployment my-release-prometheus-blackbox-exporter
+kubectl delete deployment [RELEASE_NAME]-prometheus-blackbox-exporter
 ```
 
 Note that this will cause downtime of the blackbox.
+
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+# Helm 2
+$ helm inspect values prometheus-community/prometheus
+
+# Helm 3
+$ helm show values prometheus-community/prometheus
+```

--- a/charts/prometheus-cloudwatch-exporter/CHANGELOG.md
+++ b/charts/prometheus-cloudwatch-exporter/CHANGELOG.md
@@ -4,8 +4,11 @@
 This file documents all notable changes to prometheus-cloudwatch-exporter Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
-
 NOTE: The change log until version 0.4.10 is auto generated based on git commits. Those include a reference to the git commit to be able to get more details.
+
+## 0.8.4
+
+Chart moved from stable to prometheus-community helm repo
 
 ## 0.8.1
 
@@ -127,4 +130,3 @@ commit: 647b56cc4
 
 Add cloudwatch exporter (#4022)
 commit: 0f730f26e
-

--- a/charts/prometheus-cloudwatch-exporter/Chart.yaml
+++ b/charts/prometheus-cloudwatch-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus cloudwatch-exporter
 name: prometheus-cloudwatch-exporter
-version: 0.8.3
+version: 0.8.4
 home: https://github.com/prometheus/cloudwatch_exporter
 sources:
 - https://github.com/prometheus/cloudwatch_exporter

--- a/charts/prometheus-cloudwatch-exporter/OWNERS
+++ b/charts/prometheus-cloudwatch-exporter/OWNERS
@@ -1,8 +1,0 @@
-approvers:
-- gianrubio
-- torstenwalter
-- asherf
-reviewers:
-- gianrubio
-- torstenwalter
-- asherf

--- a/charts/prometheus-cloudwatch-exporter/README.md
+++ b/charts/prometheus-cloudwatch-exporter/README.md
@@ -1,14 +1,6 @@
-# Cloudwatch exporter
+# Prometheus Cloudwatch Exporter
 
-* Installs [cloudwatch exporter](http://github.com/prometheus/cloudwatch_exporter)
-
-## TL;DR;
-
-```console
-$ helm install stable/prometheus-cloudwatch-exporter
-```
-
-## Introduction
+An exporter for [Amazon CloudWatch](http://aws.amazon.com/cloudwatch/), for Prometheus.
 
 This chart bootstraps a [cloudwatch exporter](http://github.com/prometheus/cloudwatch_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
@@ -17,95 +9,69 @@ This chart bootstraps a [cloudwatch exporter](http://github.com/prometheus/cloud
 - [kube2iam](../../stable/kube2iam) installed to used the **aws.role** config option otherwise configure **aws.aws_access_key_id** and **aws.aws_secret_access_key** or **aws.secret.name**
 - Or an [IAM Role for service account](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/) attached to a service account with an annotation. If you run the pod as nobody in `securityContext.runAsUser` then also set `securityContext.fsGroup` to the same value so it will be able to access to the mounted secret.
 
-## Installing the Chart
-
-To install the chart with the release name `my-release`:
+## Get Repo Info
 
 ```console
-$ # pass AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY as values
-$ helm install --name my-release stable/prometheus-cloudwatch-exporter --set aws.aws_access_key_id=$AWS_ACCESS_KEY_ID,aws.aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
-
-$ # or store them in a secret and pass its name as a value
-$ kubectl create secret generic <SECRET_NAME> --from-literal=access_key=$AWS_ACCESS_KEY_ID --from-literal=secret_key=$AWS_SECRET_ACCESS_KEY
-$ helm install --name my-release stable/prometheus-cloudwatch-exporter --set aws.secret.name=<SECRET_NAME>
-
-$ # or add a role to aws with the [correct policy](https://github.com/prometheus/cloudwatch_exporter#credentials-and-permissions) to add to cloud watch and pass its name as a value
-$ helm install --name my-release stable/prometheus-cloudwatch-exporter --set awsRole=<ROLL_NAME>
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo update
 ```
 
-The command deploys Cloudwatch exporter on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-## Uninstalling the Chart
-
-To uninstall/delete the `my-release` deployment:
+## Install Chart
 
 ```console
-$ helm delete my-release
+# Helm 3
+$ helm install [RELEASE_NAME] prometheus-community/prometheus-cloudwatch-exporter
+
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-cloudwatch-exporter
 ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+_See [configuration](#configuration) below._
 
-## Configuration
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-The following table lists the configurable parameters of the Cloudwatch Exporter chart and their default values.
-
-| Parameter                         | Description                                                             | Default                     |
-| --------------------------------- | ----------------------------------------------------------------------- | --------------------------- |
-| `image.repository`                | Image                                                                   | `prom/cloudwatch-exporter`  |
-| `image.tag`                       | Image tag                                                               | `cloudwatch_exporter-0.8.0` |
-| `image.pullPolicy`                | Image pull policy                                                       | `IfNotPresent`              |
-| `command`                         | Container entrypoint command                                            | `[]`                        |
-| `containerPort`                   | Application listening port                                              | `9106`                      |
-| `service.type`                    | Service type                                                            | `ClusterIP`                 |
-| `service.port`                    | The service port                                                        | `80`                        |
-| `service.portName`                | The name of the service port                                            | `http`                      |
-| `service.annotations`             | Custom annotations for service                                          | `{}`                        |
-| `service.labels`                  | Additional custom labels for the service                                | `{}`                        |
-| `resources`                       |                                                                         | `{}`                        |
-| `aws.role`                        | AWS IAM Role To Use                                                     |                             |
-| `aws.aws_access_key_id`           | AWS access key id                                                       |                             |
-| `aws.aws_secret_access_key`       | AWS secret access key                                                   |                             |
-| `aws.secret.name`                 | The name of a pre-created secret in which AWS credentials are stored    |                             |
-| `aws.secret.includesSessionToken` | Whether or not the pre-created secret contains an AWS STS session token |                             |
-| `config`                          | Cloudwatch exporter configuration                                       | `example configuration`     |
-| `rbac.create`                     | If true, create & use RBAC resources                                    | `false`                     |
-| `serviceAccount.create`           | Specifies whether a service account should be created.                  | `true`                      |
-| `serviceAccount.name`             | Name of the service account.                                            |                             |
-| `serviceAccount.annotations`      | Custom annotations for service  account.                                | `{}`                        |
-| `tolerations`                     | Add tolerations                                                         | `[]`                        |
-| `nodeSelector`                    | node labels for pod assignment                                          | `{}`                        |
-| `affinity`                        | node/pod affinities                                                     | `{}`                        |
-| `livenessProbe`                   | Liveness probe settings                                                 |                             |
-| `readinessProbe`                  | Readiness probe settings                                                |                             |
-| `serviceMonitor.enabled`          | Use servicemonitor from prometheus operator                             | `false`                     |
-| `serviceMonitor.namespace`        | Namespace thes Servicemonitor  is installed in                          |                             |
-| `serviceMonitor.interval`         | How frequently Prometheus should scrape                                 |                             |
-| `serviceMonitor.telemetryPath`    | path to cloudwatch-exporter telemtery-path                              |                             |
-| `serviceMonitor.labels`           | labels for the ServiceMonitor passed to Prometheus Operator             | `{}`                        |
-| `serviceMonitor.timeout`          | Timeout after which the scrape is ended                                 |                             |
-| `serviceMonitor.relabelings`      | RelabelConfigs to apply to samples before scraping.                     |                             |
-| `serviceMonitor.metricRelabelings`| MetricRelabelConfigs to apply to samples before ingestion.              |                             |
-| `prometheusRule.enabled`          | Namespace thes PrometheusRule  is installed in                          | `false`                     |
-| `prometheusRule.namespace`        | Use PrometheusRule from prometheus operator                             |                             |
-| `prometheusRule.labels`           | labels for the prometheusRule passed to Prometheus Operator             |                             |
-| `prometheusRule.rules`            | Specify alerting rules in YAML format for PrometheusRule                |                             |
-| `ingress.enabled`                 | Enables Ingress                                                         | `false`                     |
-| `ingress.annotations`             | Ingress annotations                                                     | `{}`                        |
-| `ingress.labels`                  | Custom labels                                                           | `{}`                        |
-| `ingress.hosts`                   | Ingress accepted hostnames                                              | `[]`                        |
-| `ingress.tls`                     | Ingress TLS configuration                                               | `[]`                        |
-| `securityContext`                 | Security Context for the pod                                            | `{}`                        |
-
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+## Uninstall Chart
 
 ```console
-$ helm install --name my-release \
-    --set aws.role=my-aws-role \
-    stable/prometheus-cloudwatch-exporter
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
 ```
 
-Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
 
 ```console
-$ helm install --name my-release -f values.yaml stable/prometheus-cloudwatch-exporter
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
 ```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+## Configuring
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+# Helm 2
+$ helm inspect values prometheus-community/prometheus-cloudwatch-exporter
+
+# Helm 3
+$ helm show values prometheus-community/prometheus-cloudwatch-exporter
+```
+
+### AWS Credentials or Role
+
+For Cloudwatch Exporter to operate properly, you must configure either AWS credentials or an AWS role with the [correct policy](https://github.com/prometheus/cloudwatch_exporter#credentials-and-permissions).
+
+- To configure AWS credentials by value, set `aws.aws_access_key_id` to your [AWS_ACCESS_KEY_ID], and `aws.aws_secret_access_key` to [AWS_SECRET_ACCESS_KEY].
+- To configure AWS credentials by secret, you must store them in a secret (`kubectl create secret generic [SECRET_NAME] --from-literal=access_key=[AWS_ACCESS_KEY_ID] --from-literal=secret_key=[AWS_SECRET_ACCESS_KEY]`) and set `aws.secret.name` to [SECRET_NAME]
+- To configure an AWS role (with correct policy linked above), set `awsRole` to [ROLL_NAME]

--- a/charts/prometheus-cloudwatch-exporter/README.md
+++ b/charts/prometheus-cloudwatch-exporter/README.md
@@ -13,7 +13,6 @@ This chart bootstraps a [cloudwatch exporter](http://github.com/prometheus/cloud
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo update
 ```
 

--- a/charts/prometheus-consul-exporter/Chart.yaml
+++ b/charts/prometheus-consul-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.4.0"
 description: A Helm chart for the Prometheus Consul Exporter
 name: prometheus-consul-exporter
-version: 0.1.5
+version: 0.1.6
 keywords:
   - metrics
   - consul

--- a/charts/prometheus-consul-exporter/README.md
+++ b/charts/prometheus-consul-exporter/README.md
@@ -12,7 +12,6 @@ This chart creates a [Consul Exporter](https://github.com/prometheus/consul_expo
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo update
 ```
 

--- a/charts/prometheus-consul-exporter/README.md
+++ b/charts/prometheus-consul-exporter/README.md
@@ -1,60 +1,76 @@
-# Consul Exporter
+# Prometheus Consul Exporter
 
-Prometheus exporter for Consul metrics.
-Learn more: https://github.com/prometheus/consul_exporter
+A Prometheus exporter for [Consul](https://www.consul.io/) metrics.
 
-## TL:DR
-
-```bash
-$ helm install stable/consul-exporter
-```
-```bash
-$ helm install stable/consul-exporter --set consulServer=my.consul.com:8500
-```
-
-## Introduction
-
-This chart creates a Consul-Exporter deployment on a
-[Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart creates a [Consul Exporter](https://github.com/prometheus/consul_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
 - Kubernetes 1.8+ with Beta APIs enabled
 
-## Installing the Chart
+## Get Repo Info
 
-To install the chart with the release name `my-release`:
-```bash
-$ helm install --name my-release stable/consul-exporter
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo update
 ```
-```bash
-$ helm install --name my-release stable/consul-exporter --set consulServer=my.consul.com --set consulPort=8500
-```
-The command deploys Consul-Exporter on the Kubernetes cluster using the
-default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
 
-## Uninstalling the Chart
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-To uninstall/delete the `my-release` deployment:
-```bash
-$ helm delete --purge my-release
+## Install Chart
+
+```console
+# Helm 3
+$ helm install [RELEASE_NAME] prometheus-community/prometheus-consul-exporter
+
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-consul-exporter
 ```
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
 ## Configuration
 
-Check the [Flags](https://github.com/prometheus/consul_exporter#flags) list and add to the options block in your value overrides.
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
-Specify each parameter using the `--set key=value[,key=value]` argument to
-`helm install`. For example,
-```bash
-$ helm install --name my-release \
-    --set key_1=value_1,key_2=value_2 \
-    stable/consul-exporter
+```console
+# Helm 2
+$ helm inspect values prometheus-community/prometheus-consul-exporter
+
+# Helm 3
+$ helm show values prometheus-community/prometheus-consul-exporter
 ```
-Alternatively, a YAML file that specifies the values for the parameters can be
-provided while installing the chart. For example,
-```bash
-# example for staging
-$ helm install --name my-release -f values.yaml stable/consul-exporter
-```
+
+### Consul Server Info
+
+Set `consulServer` to `[MY_CONSUL_HOST]:[MY_CONSUL_PORT]`.
+
+### Flags
+
+Check the [Flags](https://github.com/prometheus/consul_exporter#flags) list and add to the `options` block in your value overrides.

--- a/charts/prometheus-couchdb-exporter/Chart.yaml
+++ b/charts/prometheus-couchdb-exporter/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart to export the metrics from couchdb in Prometheus format.
 name: prometheus-couchdb-exporter
 home: https://github.com/gesellix/couchdb-prometheus-exporter
-version: 0.1.1
+version: 0.1.2
 keywords:
 - couchdb-exporter
 sources:

--- a/charts/prometheus-couchdb-exporter/README.md
+++ b/charts/prometheus-couchdb-exporter/README.md
@@ -12,7 +12,6 @@ This chart bootstraps a [CouchDB Exporter](https://github.com/gesellix/couchdb-p
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo update
 ```
 

--- a/charts/prometheus-couchdb-exporter/README.md
+++ b/charts/prometheus-couchdb-exporter/README.md
@@ -1,80 +1,68 @@
 # prometheus-couchdb-exporter
 
-[couchdb-prometheus-exporter](https://github.com/gesellix/couchdb-prometheus-exporter) is a Prometheus exporter for CouchDB metrics.
+A Prometheus exporter for [CouchDB](https://couchdb.apache.org/) metrics.
 
-## TL;DR;
-
-```bash
-$ helm install stable/prometheus-couchdb-exporter
-```
-
-## Introduction
-
-This chart bootstraps a [couchdb-exporter](https://github.com/gesellix/couchdb-prometheus-exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [CouchDB Exporter](https://github.com/gesellix/couchdb-prometheus-exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
 - Kubernetes 1.8+ with Beta APIs enabled
 
-## Installing the Chart
+## Get Repo Info
 
-To install the chart with the release name `my-release`:
-
-```bash
-$ helm install --name my-release stable/prometheus-couchdb-exporter
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo update
 ```
 
-The command deploys prometheus-couchdb-exporter on the Kubernetes cluster in the default configuration.
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-## Uninstalling the Chart
+## Install Chart
 
-To uninstall/delete the `my-release` deployment:
+```console
+# Helm 3
+$ helm install [RELEASE_NAME] prometheus-community/prometheus-couchdb-exporter
 
-```bash
-$ helm delete my-release
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-couchdb-exporter
 ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
 ## Configuration
 
-The following table lists the configurable parameters and their default values.
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
-| Parameter              | Description                                         | Default                                 |
-| ---------------------- | --------------------------------------------------- | --------------------------------------- |
-| `replicaCount`         | desired number of prometheus-couchdb-exporter pods  | `1`                                     |
-| `image.repository`     | prometheus-couchdb-exporter image repository        | `gesellix/couchdb-prometheus-exporter`  |
-| `image.tag`            | prometheus-couchdb-exporter image tag               | `16`                                    |
-| `image.pullPolicy`     | image pull policy                                   | `IfNotPresent`                          |
-| `service.type`         | desired service type                                | `ClusterIP`                             |
-| `service.port`         | service external port                               | `9984`                                  |
-| `ingress.enabled`      | enable ingress controller resource                  | `false`                                 |
-| `ingress.annotations`  | annotations for the host's ingress records          | `false`                                 |
-| `ingress.path`         | path for the ingress route                          | `/`                                     |
-| `ingress.hosts`        | list of host address for ingress creation           |                                         |
-| `ingress.tls`          | utilize TLS backend in ingress                      |                                         |
-| `resources`            | cpu/memory resource requests/limits                 | {}                                      |
-| `nodeSelector`         | node labels for pod assignment                      | {}                                      |
-| `tolerations`          | tolerations for pod assignment                      | {}                                      |
-| `affinity`             | affinity settings for proxy pod assignments         | {}                                      |
-| `couchdb.uri`          | address of the couchdb                              | `http://couchdb.default.svc:5984`       |
-| `couchdb.databases`    | comma separated databases to monitor                | `_all_dbs`                              |
-| `couchdb.username`     | username for couchdb                                |                                         |
-| `couchdb.password`     | password for couchdb                                |                                         |
+```console
+# Helm 2
+$ helm inspect values prometheus-community/prometheus-couchdb-exporter
 
-
-For more information please refer to the [couchdb-prometheus-exporter]https://github.com/gesellix/couchdb-prometheus-exporter) documentation.
-
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
-
-```bash
-$ helm install --name my-release \
-  --set "couchdb.uri=http://mycouchdb:5984" \
-    stable/prometheus-couchdb-exporter
-```
-
-Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
-
-```bash
-$ helm install --name my-release -f values.yaml stable/prometheus-couchdb-exporter
+# Helm 3
+$ helm show values prometheus-community/prometheus-couchdb-exporter
 ```

--- a/charts/prometheus-couchdb-exporter/templates/deployment.yaml
+++ b/charts/prometheus-couchdb-exporter/templates/deployment.yaml
@@ -43,12 +43,12 @@ spec:
             httpGet:
               path: /
               port: http
-              initialDelaySeconds: 60
+            initialDelaySeconds: 60
           readinessProbe:
             httpGet:
               path: /
               port: http
-              initialDelaySeconds: 60
+            initialDelaySeconds: 60
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/charts/prometheus-couchdb-exporter/templates/podsecuritypolicy.yaml
+++ b/charts/prometheus-couchdb-exporter/templates/podsecuritypolicy.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "prometheus-couchdb-exporter.fullname" . }}

--- a/charts/prometheus-mongodb-exporter/Chart.yaml
+++ b/charts/prometheus-mongodb-exporter/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 name: prometheus-mongodb-exporter
 sources:
 - https://github.com/percona/mongodb_exporter
-version: 2.8.0
+version: 2.8.1

--- a/charts/prometheus-mongodb-exporter/OWNERS
+++ b/charts/prometheus-mongodb-exporter/OWNERS
@@ -1,4 +1,0 @@
-approvers:
-  - steven-sheehy
-reviewers:
-  - steven-sheehy

--- a/charts/prometheus-mongodb-exporter/README.md
+++ b/charts/prometheus-mongodb-exporter/README.md
@@ -9,7 +9,6 @@ MongoDB Exporter collects and exports oplog, replica set, server status, shardin
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo update
 ```
 

--- a/charts/prometheus-mongodb-exporter/README.md
+++ b/charts/prometheus-mongodb-exporter/README.md
@@ -1,70 +1,81 @@
 # Prometheus MongoDB Exporter
 
+A Prometheus exporter for [MongoDB](https://www.mongodb.com/) metrics.
+
 Installs the [MongoDB Exporter](https://github.com/percona/mongodb_exporter) for [Prometheus](https://prometheus.io/). The
 MongoDB Exporter collects and exports oplog, replica set, server status, sharding and storage engine metrics.
 
-## Installing the Chart
-
-To install the chart with the release name `my-release`:
+## Get Repo Info
 
 ```console
-$ helm upgrade --install my-release stable/prometheus-mongodb-exporter
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo update
 ```
 
-This command deploys the MongoDB Exporter with the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-## Using the Chart
+## Install Chart
 
-To use the chart, ensure the `mongodb.uri` is populated with a valid [MongoDB URI](https://docs.mongodb.com/manual/reference/connection-string)
-or an existing secret (in the releases namespace) containing the key defined on `existingSecret.key`, with the URI is referred via `existingSecret.name`. If no secret key is defined, the default value is `mongodb-uri`.
-If the MongoDB server requires authentication, credentials should be populated in the connection string as well. The MongoDB Exporter supports
-connecting to either a MongoDB replica set member, shard, or standalone instance.
+```console
+# Helm 3
+$ helm install [RELEASE_NAME] prometheus-community/prometheus-mongodb-exporter
 
-The chart comes with a ServiceMonitor for use with the [Prometheus Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator).
-If you're not using the Prometheus Operator, you can disable the ServiceMonitor by setting `serviceMonitor.enabled` to `false` and instead
-populate the `podAnnotations` as below:
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-mongodb-exporter
+```
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+# Helm 2
+$ helm inspect values prometheus-community/prometheus-mongodb-exporter
+
+# Helm 3
+$ helm show values prometheus-community/prometheus-mongodb-exporter
+```
+
+### MongoDB Server Connection
+
+To use the chart, ensure the `mongodb.uri` is populated with a valid [MongoDB URI](https://docs.mongodb.com/manual/reference/connection-string) or an existing secret (in the releases namespace) containing the key defined on `existingSecret.key`, with the URI is referred via `existingSecret.name`. If no secret key is defined, the default value is `mongodb-uri`.
+
+If the MongoDB server requires authentication, credentials should be populated in the connection string as well. The MongoDB Exporter supports connecting to either a MongoDB replica set member, shard, or standalone instance.
+
+### Service Monitor
+
+The chart comes with a ServiceMonitor for use with the [Prometheus Operator](https://github.com/helm/charts/tree/master/stable/prometheus-operator). If you're not using the Prometheus Operator, you can disable the ServiceMonitor by setting `serviceMonitor.enabled` to `false` and instead populate the `podAnnotations` as below:
 
 ```yaml
 podAnnotations:
   prometheus.io/scrape: "true"
   prometheus.io/port: "metrics"
 ```
-
-## Configuration
-
-| Parameter | Description | Default |
-|-----------|-------------|---------|
-| `affinity` | Node/pod affinities | `{}` |
-| `annotations` | Annotations to be added to the pods | `{}` |
-| `existingSecret.name` | Refer to an existing secret name instead of using `mongodb.uri` | `` |
-| `existingSecret.key` | Refer to an existing secret key | `mongodb-uri` |
-| `extraArgs` | The extra command line arguments to pass to the MongoDB Exporter  | See values.yaml |
-| `fullnameOverride` | Override the full chart name | `` |
-| `image.pullPolicy` | MongoDB Exporter image pull policy | `IfNotPresent` |
-| `image.repository` | MongoDB Exporter image name | `ssheehy/mongodb-exporter` |
-| `image.tag` | MongoDB Exporter image tag | `0.10.0` |
-| `imagePullSecrets` | List of container registry secrets | `[]` |
-| `mongodb.uri` | The [URI](https://docs.mongodb.com/manual/reference/connection-string) to connect to MongoDB | `` |
-| `nameOverride` | Override the application name  | `` |
-| `nodeSelector` | Node labels for pod assignment | `{}` |
-| `podAnnotations` | Annotations to be added to all pods | `{}` |
-| `port` | The container port to listen on | `9216` |
-| `priorityClassName` | Pod priority class name | `` |
-| `replicas` | Number of replicas in the replica set | `1` |
-| `resources` | Pod resource requests and limits | `{}` |
-| `env` | Extra environment variables passed to pod | `{}` |
-| `securityContext` | Security context for the pod | See values.yaml |
-| `service.labels` | Additional labels for the service definition | `{}` |
-| `service.annotations` | Annotations to be added to the service | `{}` |
-| `service.port` | The port to expose | `9216` |
-| `service.type` | The type of service to expose | `ClusterIP` |
-| `serviceAccount.create` | If `true`, create the service account | `true` |
-| `serviceAccount.name` | Name of the service account | `` |
-| `serviceMonitor.enabled` | Set to true if using the Prometheus Operator | `true` |
-| `serviceMonitor.interval` | Interval at which metrics should be scraped | `30s` |
-| `serviceMonitor.scrapeTimeout` | Interval at which metric scrapes should time out | `10s` |
-| `serviceMonitor.namespace` | The namespace where the Prometheus Operator is deployed | `` |
-| `serviceMonitor.additionalLabels` | Additional labels to add to the ServiceMonitor | `{}` |
-| `serviceMonitor.targetLabels` | Set of labels to transfer on the Kubernetes Service onto the target. | `[]`
-| `serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion. | `[]` |
-| `tolerations` | List of node taints to tolerate  | `[]` |

--- a/charts/prometheus-mysql-exporter/Chart.yaml
+++ b/charts/prometheus-mysql-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for prometheus mysql exporter with cloudsqlproxy
 name: prometheus-mysql-exporter
-version: 0.7.0
+version: 0.7.1
 home: https://github.com/prometheus/mysqld_exporter
 appVersion: v0.11.0
 sources:

--- a/charts/prometheus-mysql-exporter/OWNERS
+++ b/charts/prometheus-mysql-exporter/OWNERS
@@ -1,6 +1,0 @@
-approvers:
-- juanchimienti
-- monotek
-reviewers:
-- juanchimienti
-- monotek

--- a/charts/prometheus-mysql-exporter/README.md
+++ b/charts/prometheus-mysql-exporter/README.md
@@ -8,7 +8,6 @@ This chart bootstraps a Prometheus [MySQL Exporter](http://github.com/prometheus
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo update
 ```
 

--- a/charts/prometheus-mysql-exporter/README.md
+++ b/charts/prometheus-mysql-exporter/README.md
@@ -1,97 +1,80 @@
 # Prometheus Mysql Exporter
 
--   Installs prometheus [mysql exporter](https://github.com/prometheus/mysqld_exporter)
+A Prometheus exporter for [MySQL](https://www.mysql.com/) metrics.
 
-## TL;DR;
+This chart bootstraps a Prometheus [MySQL Exporter](http://github.com/prometheus/mysql_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
-```console
-$ helm install stable/prometheus-mysql-exporter
-```
-
-## Introduction
-
-This chart bootstraps a prometheus [mysql exporter](http://github.com/prometheus/mysql_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager. The exporter can connect to mysql directly or using the [Cloud SQL Proxy](https://cloud.google.com/sql/docs/mysql/sql-proxy).
-
-## Installing the Chart
-
-To install the chart with the release name `my-release`:
+## Get Repo Info
 
 ```console
-$ helm install --name my-release stable/prometheus-mysql-exporter --set mysql.user="username",mysql.pass="password",mysql.host="example.com",mysql.port="3306"
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo update
 ```
 
-The command deploys a mysql exporter on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-## Uninstalling the Chart
-
-To uninstall/delete the `my-release` deployment:
+## Install Chart
 
 ```console
-$ helm delete my-release
+# Helm 3
+$ helm install [RELEASE_NAME] prometheus-community/prometheus-mysql-exporter
+
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-mysql-exporter
 ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
 ## Configuration
 
-The following table lists the configurable parameters of the mysql exporter chart and their default values.
-
-| Parameter                              | Description                                                | Default                            |
-| -------------------------------------- | -----------------------------------------------------------| ---------------------------------- |
-| `replicaCount`                         | Amount of pods for the deployment                          | `1`                                |
-| `image.repository`                     | Image repository                                           | `prom/mysqld-exporter`             |
-| `image.tag`                            | Image tag                                                  | `v0.11.0`                          |
-| `image.pullPolicy`                     | Image pull policy                                          | `IfNotPresent`                     |
-| `service.name`                         | Service name                                               | `mysql-exporter`                   |
-| `service.labels`                       | Additional labels for the service                          | `{}`                               |
-| `service.annotations`                  | Annotations to be added to the service                     | `{}`                               |
-| `service.type`                         | Service type                                               | `ClusterIP`                        |
-| `service.externalport`                 | The service port                                           | `9104`                             |
-| `service.internalPort`                 | The target port of the container                           | `9104`                             |
-| `resources`                            | CPU/Memory resource requests/limits                        | `{}`                               |
-| `annotations`                          | pod annotations for easier discovery                       | `see values.yaml`                  |
-| `collectors`                           | Collector configuration                                    | `see values.yaml`                  |
-| `podLabels`                            | Additional labels to add to each pod                       | `{}`                               |
-| `mysql.db`                             | MySQL connection db (optional)                             | `""`                               |
-| `mysql.host`                           | MySQL connection host                                      | `localhost`                        |
-| `mysql.param`                          | MySQL connection parameters (optional)                     | `"tcp"`                            |
-| `mysql.pass`                           | MySQL connection password                                  | `password`                         |
-| `mysql.port`                           | MySQL connection port                                      | `3306`                             |
-| `mysql.protocol`                       | MySQL connection protocol (optional)                       | `""`                               |
-| `mysql.user`                           | MySQL connection username                                  | `exporter`                         |
-| `mysql.existingSecret`                 | Use existing kubernetes secret for DATA_SOURCE_NAME        | `false`                            |
-| `cloudsqlproxy.enabled`                | Flag to enable the connection using Cloud SQL Proxy        | `false`                            |
-| `cloudsqlproxy.image.repo`             | Cloud SQL Proxy image repository                           | `gcr.io/cloudsql-docker/gce-proxy` |
-| `cloudsqlproxy.image.tag`              | Cloud SQL Proxy image tag                                  | `1.14`                             |
-| `cloudsqlproxy.image.pullPolicy`       | Cloud SQL Proxy image pull policy                          | `IfNotPresent`                     |
-| `cloudsqlproxy.instanceConnectionName` | Google Cloud instance connection name                      | `project:us-central1:dbname`       |
-| `cloudsqlproxy.port`                   | Cloud SQL Proxy listening port                             | `3306`                             |
-| `cloudsqlproxy.credentials`            | Cloud SQL Proxy service account credentials                | `bogus credential file`            |
-| `serviceMonitor.enabled`               | Integration with prometheus-operator                       | `false`                            |
-| `serviceMonitor.interval`              | Interval for polling this exporter                         |                                    |
-| `serviceMonitor.scrapeTimeout`         | Timeout where exporter is considered faulty                |                                    |
-| `serviceMonitor.jobLabel`              | Label to use to retrieve the job name from                 | `""`                               |
-| `serviceMonitor.targetLabels`          | Labels to transfer from service onto the target            | `[]`                               |
-| `serviceMonitor.podTargetLabels`       | Labels to transfor from pod onto the target                | `[]`                               |
-| `serviceMonitor.metricRelabelings`     | MetricRelabelConfigs to apply to samples before ingestion. | `[]`                               |
-
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-$ helm install --name my-release \
-  --set mysql.user="username",mysql.password="password",mysql.host="localhost",mysql.port="3306"  \
-    stable/prometheus-mysql-exporter
+# Helm 2
+$ helm inspect values prometheus-community/prometheus-mysql-exporter
+
+# Helm 3
+$ helm show values prometheus-community/prometheus-mysql-exporter
 ```
 
-Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+### MySQL Connection
 
-```console
-$ helm install --name my-release -f values.yaml stable/prometheus-mysql-exporter
-```
+The exporter can connect to mysql directly or using the [Cloud SQL Proxy](https://cloud.google.com/sql/docs/mysql/sql-proxy).
+
+- To configure direct MySQL connection by value, set `mysql.user`, `mysql.pass`, `mysql.host` and `mysql.port` (see additional options in the `mysql` configuration block)
+- To configure direct MySQL connnetion by secret, you must store a connection string in a secret, and set `mysql.existingSecret` to `[SECRET_NAME]`
+
+### Exporter Documentation and Params
 
 Documentation for the MySQL Exporter can be found here: (<https://github.com/prometheus/mysqld_exporter>)
 A mysql params overview can be found here: (<https://github.com/go-sql-driver/mysql#dsn-data-source-name>)
 
-## Collector Flags
+### Collector Flags
 
 Available collector flags can be found in the [values.yaml](https://github.com/kilhyunjun/charts/blob/master/stable/prometheus-mysql-exporter/values.yaml) and a description of each flag can be found in the [mysqld_exporter](https://github.com/prometheus/mysqld_exporter#collector-flags) repository.

--- a/charts/prometheus-nats-exporter/Chart.yaml
+++ b/charts/prometheus-nats-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.6.2"
 description: A Helm chart for prometheus-nats-exporter
 name: prometheus-nats-exporter
-version: 2.5.0
+version: 2.5.1
 home: https://github.com/nats-io/prometheus-nats-exporter
 sources:
   - https://github.com/nats-io/prometheus-nats-exporter

--- a/charts/prometheus-nats-exporter/OWNERS
+++ b/charts/prometheus-nats-exporter/OWNERS
@@ -1,6 +1,0 @@
-approvers:
-- okgolove
-- caarlos0
-reviewers:
-- okgolove
-- caarlos0

--- a/charts/prometheus-nats-exporter/README.md
+++ b/charts/prometheus-nats-exporter/README.md
@@ -8,7 +8,6 @@ This chart bootstraps a prometheus [NATS Exporter](https://github.com/nats-io/pr
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo update
 ```
 

--- a/charts/prometheus-nats-exporter/README.md
+++ b/charts/prometheus-nats-exporter/README.md
@@ -1,83 +1,64 @@
 # Prometheus NATS Exporter
 
-* Installs prometheus [NATS exporter](https://github.com/nats-io/prometheus-nats-exporter)
+An Prometheus Exporter for [NATS](https://github.com/nats-io/k8s) metrics.
 
-## TL;DR;
+This chart bootstraps a prometheus [NATS Exporter](https://github.com/nats-io/prometheus-nats-exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Get Repo Info
 
 ```console
-$ helm install incubator/prometheus-nats-exporter
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo update
 ```
 
-## Introduction
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-This chart bootstraps a prometheus [NATS exporter](https://github.com/nats-io/prometheus-nats-exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
-
-## Installing the Chart
-
-To install the chart with the release name `my-release`:
+## Install Chart
 
 ```console
-$ helm install --name my-release stable/prometheus-nats-exporter
+# Helm 3
+$ helm install [RELEASE_NAME] prometheus-community/prometheus-nats-exporter
+
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-nats-exporter
 ```
 
-The command deploys NATS exporter on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+_See [configuration](#configuration) below._
 
-## Uninstalling the Chart
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-To uninstall/delete the `my-release` deployment:
+## Uninstall Chart
 
 ```console
-$ helm delete my-release
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
 ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+This removes all the Kubernetes components associated with the chart and deletes the release.
 
-## Configuration
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-The following table lists the configurable parameters of the postgres Exporter chart and their default values.
-
-| Parameter                         | Description                                             | Default                                          |
-| --------------------------------- | ------------------------------------------------------- | ------------------------------------------------ |
-| `image`                           | Image                                                   | `synadia/prometheus-nats-exporter`               |
-| `imageTag`                        | Image tag                                               | `0.6.2`                                          |
-| `imagePullPolicy`                 | Image pull policy                                       | `IfNotPresent`                                   |
-| `service.type`                    | Service type                                            | `ClusterIP`                                      |
-| `service.port`                    | The service port                                        | `80`                                             |
-| `service.targetPort`              | The target port of the container                        | `7777`                                           |
-| `serviceMonitor.enabled`          | Set to true if using the Prometheus Operator            | `false`                                          |
-| `serviceMonitor.interval`         | Interval at which metrics should be scraped             | ``                                               |
-| `serviceMonitor.namespace`        | The namespace where the Prometheus Operator is deployed | ``                                               |
-| `serviceMonitor.additionalLabels` | Additional labels to add to the ServiceMonitor          | `{}`                                             |
-| `resources`                       |                                                         | `{}`                                             |
-| `config.nats.service`             | NATS monitoring [service name][svc-name]                | `nats-nats-monitoring`                           |
-| `config.nats.namespace`           | Namespace in which NATS deployed                        | `default`                                        |
-| `config.nats.port`                | NATS monitoring service port                            | `8222`                                           |
-| `config.metrics.varz`             | NATS varz metrics                                       | `true`                                           |
-| `config.metrics.channelz`         | NATS channelz metrics                                   | `true`                                           |
-| `config.metrics.connz`            | NATS connz metrics                                      | `true`                                           |
-| `config.metrics.routez`           | NATS routez metrics                                     | `true`                                           |
-| `config.metrics.serverz`          | NATS serverz metrics                                    | `true`                                           |
-| `config.metrics.subz`             | NATS subz metrics                                       | `true`                                           |
-| `config.metrics.gatewayz          | NATS gatewayz metrics                                   | `true`                                           |
-| `tolerations`                     | Add tolerations                                         | `[]`                                             |
-| `nodeSelector`                    | node labels for pod assignment                          | `{}`                                             |
-| `affinity`                        | node/pod affinities                                     | `{}`                                             |
-| `annotations`                     | Deployment annotations                                  | `{}`                                             |
-| `extraContainers`                 | Additional sidecar containers                           | `""`                                             |
-| `extraVolumes`                    | Additional volumes for use in extraContainers           | `""`                                             |
-
-[svc-name]: https://github.com/helm/charts/blob/master/stable/nats/templates/monitoring-svc.yaml
-
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+## Upgrading Chart
 
 ```console
-$ helm install --name my-release stable/prometheus-nats-exporter \
-  --set config.nats.service=nats-production-nats-monitoring \
-  --set config.metrics.subz=false
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
 ```
 
-Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+## Configuring
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-$ helm install --name my-release stable/prometheus-nats-exporter -f values.yaml
+# Helm 2
+$ helm inspect values prometheus-community/prometheus-nats-exporter
+
+# Helm 3
+$ helm show values prometheus-community/prometheus-nats-exporter
 ```

--- a/charts/prometheus-nats-exporter/values.yaml
+++ b/charts/prometheus-nats-exporter/values.yaml
@@ -35,6 +35,7 @@ resources: {}
 
 config:
   nats:
+    # See https://github.com/helm/charts/blob/master/stable/nats/templates/monitoring-svc.yaml
     service: nats-nats-monitoring
     namespace: default
     port: 8222

--- a/charts/prometheus-node-exporter/Chart.yaml
+++ b/charts/prometheus-node-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.1
 description: A Helm chart for prometheus node-exporter
 name: prometheus-node-exporter
-version: 1.11.1
+version: 1.11.2
 home: https://github.com/prometheus/node_exporter/
 sources:
 - https://github.com/prometheus/node_exporter/

--- a/charts/prometheus-node-exporter/OWNERS
+++ b/charts/prometheus-node-exporter/OWNERS
@@ -1,6 +1,0 @@
-approvers:
-- gianrubio
-- vsliouniaev
-reviewers:
-- gianrubio
-- vsliouniaev

--- a/charts/prometheus-node-exporter/README.md
+++ b/charts/prometheus-node-exporter/README.md
@@ -1,90 +1,64 @@
 # Prometheus Node Exporter
 
-* Installs prometheus [node exporter](https://github.com/prometheus/node_exporter)
+Prometheus exporter for hardware and OS metrics exposed by *NIX kernels, written in Go with pluggable metric collectors.
 
-## TL;DR;
+This chart bootstraps a prometheus [Node Exporter](http://github.com/prometheus/node_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Get Repo Info
 
 ```console
-$ helm install stable/prometheus-node-exporter
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo update
 ```
 
-## Introduction
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-This chart bootstraps a prometheus [node exporter](http://github.com/prometheus/node_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
-
-## Installing the Chart
-
-To install the chart with the release name `my-release`:
+## Install Chart
 
 ```console
-$ helm install --name my-release stable/prometheus-node-exporter
+# Helm 3
+$ helm install [RELEASE_NAME] prometheus-community/prometheus-node-exporter
+
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-node-exporter
 ```
 
-The command deploys node exporter on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+_See [configuration](#configuration) below._
 
-## Uninstalling the Chart
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-To uninstall/delete the `my-release` deployment:
+## Uninstall Chart
 
 ```console
-$ helm delete my-release
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
 ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+This removes all the Kubernetes components associated with the chart and deletes the release.
 
-## Configuration
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-The following table lists the configurable parameters of the Node Exporter chart and their default values.
-
-|             Parameter                 |                                                          Description                                                          |                 Default                          |
-| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| `image.repository`                    | Image repository                                                                                                              | `quay.io/prometheus/node-exporter`               |
-| `image.tag`                           | Image tag                                                                                                                     | `v1.0.1`                                         |
-| `image.pullPolicy`                    | Image pull policy                                                                                                             | `IfNotPresent`                                   |
-| `extraArgs`                           | Additional container arguments                                                                                                | `[]`                                             |
-| `extraHostVolumeMounts`               | Additional host volume mounts                                                                                                 | `[]`                                             |
-| `podAnnotations`                      | Annotations to be added to node exporter pods                                                                                 | `{}`                                             |
-| `podLabels`                           | Additional labels to be added to pods                                                                                         | `{}`                                             |
-| `rbac.create`                         | If true, create & use RBAC resources                                                                                          | `true`                                           |
-| `rbac.pspEnabled`                     | Specifies whether a PodSecurityPolicy should be created.                                                                      | `true`                                           |
-| `resources`                           | CPU/Memory resource requests/limits                                                                                           | `{}`                                             |
-| `service.type`                        | Service type                                                                                                                  | `ClusterIP`                                      |
-| `service.port`                        | The service port                                                                                                              | `9100`                                           |
-| `service.targetPort`                  | The target port of the container                                                                                              | `9100`                                           |
-| `service.nodePort`                    | The node port of the service                                                                                                  |                                                  |
-| `service.listenOnAllInterfaces`       | If true, listen on all interfaces using IP `0.0.0.0`. Else listen on the IP address pod has been assigned by Kubernetes.      | `true`                                           |
-| `service.annotations`                 | Kubernetes service annotations                                                                                                | `{prometheus.io/scrape: "true"}`                 |
-| `serviceAccount.create`               | Specifies whether a service account should be created.                                                                        | `true`                                           |
-| `serviceAccount.name`                 | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                                  |
-| `serviceAccount.imagePullSecrets`     | Specify image pull secrets                                                                                                    | `[]`                                             |
-| `securityContext`                     | SecurityContext                                                                                                               | See values.yaml                                  |
-| `affinity`                            | A group of affinity scheduling rules for pod assignment                                                                       | `{}`                                             |
-| `nodeSelector`                        | Node labels for pod assignment                                                                                                | `{}`                                             |
-| `tolerations`                         | List of node taints to tolerate                                                                                               | `- effect: NoSchedule operator: Exists`          |
-| `priorityClassName`                   | Name of Priority Class to assign pods                                                                                         | `nil`                                            |
-| `endpoints`                           | list of addresses that have node exporter deployed outside of the cluster                                                     | `[]`                                             |
-| `hostNetwork`                         | Whether to expose the service to the host network                                                                             | `true`                                           |
-| `prometheus.monitor.enabled`          | Set this to `true` to create ServiceMonitor for Prometheus operator                                                           | `false`                                          |
-| `prometheus.monitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus                                         | `{}`                                             |
-| `prometheus.monitor.namespace`        | namespace where servicemonitor resource should be created                                                                     | `the same namespace as prometheus node exporter` |
-| `prometheus.monitor.relabelings`      | Relabelings that should be applied on the ServerMonitor                                                                       | `{}` |
-| `prometheus.monitor.scrapeTimeout`    | Timeout after which the scrape is ended                                                                                       | `10s`                                            |
-| `configmaps`                          | Allow mounting additional configmaps.                                                                                         | `[]`                                             |
-| `namespaceOverride`                   | Override the deployment namespace                                                                                             | `""` (`Release.Namespace`)                       |
-| `updateStrategy`                      | Configure a custom update strategy for the daemonset                                                                          | `Rolling update with 1 max unavailable`          |
-| `sidecars`               | Additional containers for export metrics to text file     | `[]`           |  |
-| `sidecarVolumeMount`               | Volume for sidecar containers     | `[]`           |  |
-
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+## Upgrading Chart
 
 ```console
-$ helm install --name my-release \
-  --set serviceAccount.name=node-exporter  \
-    stable/prometheus-node-exporter
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
 ```
 
-Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+## Configuring
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-$ helm install --name my-release -f values.yaml stable/prometheus-node-exporter
+# Helm 2
+$ helm inspect values prometheus-community/prometheus-node-exporter
+
+# Helm 3
+$ helm show values prometheus-community/prometheus-node-exporter
 ```

--- a/charts/prometheus-node-exporter/README.md
+++ b/charts/prometheus-node-exporter/README.md
@@ -8,7 +8,6 @@ This chart bootstraps a prometheus [Node Exporter](http://github.com/prometheus/
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo update
 ```
 

--- a/charts/prometheus-operator/Chart.yaml
+++ b/charts/prometheus-operator/Chart.yaml
@@ -1,18 +1,15 @@
 apiVersion: v1
-description: Provides easy monitoring definitions for Kubernetes services, and deployment and management of Prometheus instances.
+deprecated: true
+description: DEPRECATED - This chart will be renamed. See https://github.com/prometheus-community/community/issues/28#issuecomment-670406329
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
 engine: gotpl
-maintainers:
-  - name: vsliouniaev
-  - name: bismarck
-  - name: gianrubio
-    email: gianrubio@gmail.com
+maintainers: []
 name: prometheus-operator
 sources:
   - https://github.com/coreos/kube-prometheus
   - https://github.com/coreos/prometheus-operator
   - https://coreos.com/operators/prometheus
-version: 9.3.1
+version: 9.3.2
 appVersion: 0.38.1
 tillerVersion: ">=2.12.0"
 home: https://github.com/coreos/prometheus-operator

--- a/charts/prometheus-operator/README.md
+++ b/charts/prometheus-operator/README.md
@@ -1,3 +1,7 @@
+# ⚠️ DEPRECATED
+
+This chart will be renamed, but first must be deprecated before the prometheus-community/helm-charts repo is indexed, so that it won't be listed in the hubs. See [this prometheus-community issue](https://github.com/prometheus-community/community/issues/28#issuecomment-670406329) for reasoning and next steps.
+
 # prometheus-operator
 
 Installs [prometheus-operator](https://github.com/coreos/prometheus-operator) to create/configure/manage Prometheus clusters atop Kubernetes. This chart includes multiple components and is suitable for a variety of use-cases.

--- a/charts/prometheus-operator/templates/NOTES.txt
+++ b/charts/prometheus-operator/templates/NOTES.txt
@@ -1,3 +1,7 @@
+DEPRECATED - This chart will be renamed. See https://github.com/prometheus-community/community/issues/28#issuecomment-670406329
+
+---
+
 The Prometheus Operator has been installed. Check its status by running:
   kubectl --namespace {{ template "prometheus-operator.namespace" . }} get pods -l "release={{ $.Release.Name }}"
 

--- a/charts/prometheus-postgres-exporter/Chart.yaml
+++ b/charts/prometheus-postgres-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A Helm chart for prometheus postgres-exporter
 name: prometheus-postgres-exporter
-version: 1.3.0
+version: 1.3.1
 home: https://github.com/wrouesnel/postgres_exporter
 sources:
 - https://github.com/wrouesnel/postgres_exporter

--- a/charts/prometheus-postgres-exporter/README.md
+++ b/charts/prometheus-postgres-exporter/README.md
@@ -1,89 +1,64 @@
 # Prometheus Postgres Exporter
 
-* Installs prometheus [postgres exporter](https://github.com/wrouesnel/postgres_exporter)
-
-## TL;DR;
-
-```console
-$ helm install stable/prometheus-postgres-exporter
-```
-
-## Introduction
+Prometheus exporter for [PostgreSQL](https://www.postgresql.org/about/servers/) server metrics.
 
 This chart bootstraps a prometheus [postgres exporter](https://github.com/wrouesnel/postgres_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
-## Installing the Chart
-
-To install the chart with the release name `my-release`:
+## Get Repo Info
 
 ```console
-$ helm install --name my-release stable/prometheus-postgres-exporter
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo update
 ```
 
-The command deploys postgres exporter on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-## Uninstalling the Chart
-
-To uninstall/delete the `my-release` deployment:
+## Install Chart
 
 ```console
-$ helm delete my-release
+# Helm 3
+$ helm install [RELEASE_NAME] prometheus-community/prometheus-postgres-exporter
+
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-postgres-exporter
 ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+_See [configuration](#configuration) below._
 
-## Configuration
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-The following table lists the configurable parameters of the postgres Exporter chart and their default values.
-
-| Parameter                       | Description                                | Default                                                    |
-| ------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
-| `image`                         | Image                                      | `wrouesnel/postgres_exporter`                      |
-| `imageTag`                      | Image tag                                  | `v0.5.1`                                      |
-| `imagePullPolicy`               | Image pull policy                          | `IfNotPresent` |
-| `service.annotations`           | annotations for the service                | `{}`           |
-| `service.type`      | Service type |  `ClusterIP` |
-| `service.port`                      | The service port                               | `80`                                     |
-| `service.targetPort`                      | The target port of the container                               | `9187`                                        |
-| `service.name`                  | Name of the service port                   | `http`                                                     |
-| `service.labels`                | Labels to add to the service               | `{}`                                                       |
-| `serviceMonitor.enabled`          | Use servicemonitor from prometheus operator                             | `false`                     |
-| `serviceMonitor.namespace`        | Namespace thes Servicemonitor  is installed in                          |                             |
-| `serviceMonitor.interval`         | How frequently Prometheus should scrape                                 |                             |
-| `serviceMonitor.telemetryPath`    | path to cloudwatch-exporter telemtery-path                              |                             |
-| `serviceMonitor.labels`           | labels for the ServiceMonitor passed to Prometheus Operator             | `{}`                        |
-| `serviceMonitor.timeout`          | Timeout after which the scrape is ended                                 |                             |
-| `resources`          |                                  |                    `{}`                                  |
-| `config.datasource`                 | Postgresql datasource configuration                      |  see [values.yaml](values.yaml)              |
-| `config.datasourceSecret`       | Postgresql datasource configuration from secret                  |  see [values.yaml](values.yaml)              |
-| `config.queries`                | SQL queries that the exporter will run | [postgres exporter defaults](https://github.com/wrouesnel/postgres_exporter/blob/master/queries.yaml) |
-| `config.disableDefaultMetrics`  | Specifies whether to use only metrics from `queries.yaml`| `false` |
-| `config.autoDiscoverDatabases`  | Specifies whether to autodiscover all databases | `false` |
-| `config.excludeDatabases`  | When autodiscover is enabled, list databases to exclude| `[]` |
-| `rbac.create`                   | Specifies whether RBAC resources should be created.| `true` |
-| `rbac.pspEnabled`               | Specifies whether a PodSecurityPolicy should be created.| `true` |
-| `serviceAccount.create`         | Specifies whether a service account should be created.| `true` |
-| `serviceAccount.name`           | Name of the service account.|        |
-| `tolerations`                   | Add tolerations                            | `[]`  |
-| `nodeSelector`                    | node labels for pod assignment | `{}`  |
-| `affinity`                       |     node/pod affinities | `{}` |
-| `annotations`                    | Deployment annotations | `{}` |
-| `podLabels`                      | Additional labels to add to each pod      | `{}` |
-| `extraContainers`                | Additional sidecar containers | `""` |
-| `extraVolumes`                   | Additional volumes for use in extraContainers | `""` |
-| `securityContext`                | Security options the pod should run with. [More info](https://kubernetes.io/docs/concepts/policy/security-context/) | `{}` |
-
-
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+## Uninstall Chart
 
 ```console
-$ helm install --name my-release \
-  --set serviceAccount.name=postgres  \
-    stable/prometheus-postgres-exporter
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
 ```
 
-Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
 
 ```console
-$ helm install --name my-release -f values.yaml stable/prometheus-postgres-exporter
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+## Configuring
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+# Helm 2
+$ helm inspect values prometheus-community/prometheus-postgres-exporter
+
+# Helm 3
+$ helm show values prometheus-community/prometheus-postgres-exporter
 ```

--- a/charts/prometheus-postgres-exporter/README.md
+++ b/charts/prometheus-postgres-exporter/README.md
@@ -8,7 +8,6 @@ This chart bootstraps a prometheus [postgres exporter](https://github.com/wroues
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo update
 ```
 

--- a/charts/prometheus-pushgateway/Chart.yaml
+++ b/charts/prometheus-pushgateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.2.0"
 description: A Helm chart for prometheus pushgateway
 name: prometheus-pushgateway
-version: 1.4.1
+version: 1.4.2
 home: https://github.com/prometheus/pushgateway
 sources:
 - https://github.com/prometheus/pushgateway

--- a/charts/prometheus-pushgateway/OWNERS
+++ b/charts/prometheus-pushgateway/OWNERS
@@ -1,6 +1,0 @@
-approvers:
-- gianrubio
-- cstaud
-reviewers:
-- gianrubio
-- cstaud

--- a/charts/prometheus-pushgateway/README.md
+++ b/charts/prometheus-pushgateway/README.md
@@ -8,7 +8,6 @@ An optional prometheus `ServiceMonitor` can be enabled, should you wish to use t
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo update
 ```
 

--- a/charts/prometheus-pushgateway/README.md
+++ b/charts/prometheus-pushgateway/README.md
@@ -1,92 +1,64 @@
 # Prometheus Pushgateway
 
-* Installs prometheus [pushgateway](https://github.com/prometheus/pushgateway)
-
-## TL;DR;
-
-```console
-$ helm install stable/prometheus-pushgateway
-```
-
-## Introduction
-
 This chart bootstraps a prometheus [pushgateway](http://github.com/prometheus/pushgateway) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 An optional prometheus `ServiceMonitor` can be enabled, should you wish to use this gateway with a [Prometheus Operator](https://github.com/coreos/prometheus-operator).
 
-## Installing the Chart
-
-To install the chart with the release name `my-release`:
+## Get Repo Info
 
 ```console
-$ helm install --name my-release stable/prometheus-pushgateway
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo update
 ```
 
-The command deploys pushgateway on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-## Uninstalling the Chart
-
-To uninstall/delete the `my-release` deployment:
+## Install Chart
 
 ```console
-$ helm delete my-release
+# Helm 3
+$ helm install [RELEASE_NAME] prometheus-community/prometheus-pushgateway
+
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-pushgateway
 ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
 ## Configuration
 
-The following table lists the configurable parameters of the pushgateway chart and their default values.
-
-|        Parameter                  |                                                          Description                                                          |      Default                      |
-| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
-| `affinity`                        | Affinity settings for pod assignment                                                                                          | `{}`                              |
-| `extraArgs`                       | Optional flags for pushgateway                                                                                                | `[]`                              |
-| `extraVars`                       | Optional environment variables for pushgateway                                                                                | `[]`                              |
-| `image.repository`                | Image repository                                                                                                              | `prom/pushgateway`                |
-| `image.tag`                       | Image tag                                                                                                                     | `v1.2.0`                          |
-| `image.pullPolicy`                | Image pull policy                                                                                                             | `IfNotPresent`                    |
-| `ingress.enabled`                 | Enables Ingress for pushgateway                                                                                               | `false`                           |
-| `ingress.annotations`             | Ingress annotations                                                                                                           | `{}`                              |
-| `ingress.hosts`                   | Ingress accepted hostnames                                                                                                    | `nil`                             |
-| `ingress.tls`                     | Ingress TLS configuration                                                                                                     | `[]`                              |
-| `resources`                       | CPU/Memory resource requests/limits                                                                                           | `{}`                              |
-| `replicaCount`                    | Number of replicas                                                                                                            | `1`                               |
-| `strategy`                        | Deployment strategy                                                                                                           | `{ "type": "Recreate" }`          |
-| `service.type`                    | Service type                                                                                                                  | `ClusterIP`                       |
-| `service.port`                    | The service port                                                                                                              | `9091`                            |
-| `service.nodePort`                | The optional service node port when `service.type` is `NodePort`                                                              | ``                                |
-| `service.targetPort`              | The target port of the container                                                                                              | `9091`                            |
-| `serviceAnnotations`              | Annotations for the service                                                                                                   | `{}`                              |
-| `serviceLabels`                   | Labels for service                                                                                                            | `{}`                              |
-| `serviceAccount.create`           | Specifies whether a service account should be created.                                                                        | `true`                            |
-| `serviceAccount.name`             | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |                                   |
-| `tolerations`                     | List of node taints to tolerate                                                                                               | `{}`                              |
-| `nodeSelector`                    | Node labels for pod assignment                                                                                                | `{}`                              |
-| `podAnnotations`                  | Annotations for pod                                                                                                           | `{}`                              |
-| `podLabels`                       | Labels for pod                                                                                                                | `{}`                              |
-| `serviceAccountLabels`            | Labels for service account                                                                                                    | `{}`                              |
-| `persistentVolumeLabels`          | Labels for persistent volume                                                                                                  | `{}`                              |
-| `serviceMonitor.enabled`          | if `true`, creates a Prometheus Operator ServiceMonitor                                                                       | `false`                           |
-| `serviceMonitor.namespace`        | Namespace which Prometheus is running in                                                                                      | `monitoring`                      |
-| `serviceMonitor.interval`         | How frequently to scrape metrics (use by default, falling back to Prometheus' default)                                        | `nil`                             |
-| `serviceMonitor.scrapeTimeout`    | How long to scrape metrics before timing out. (use by default, falling back to Prometheus' default)                           | `nil`                             |
-| `serviceMonitor.additionalLables` | Used to pass Labels that are required by the Installed Prometheus Operator                                                    | `{}`                              |
-| `serviceMonitor.honorLabels`      | if `true`, label conflicts are resolved by keeping label values from the scraped data                                         | `true`                            |
-| `podDisruptionBudget`             | If set, create a PodDisruptionBudget with the items in this map set in the spec                                               | ``                                |
-| `networkPolicy.allowAll`          | Allow connectivity from all pods in the cluster                                                                               | ``                                |
-| `networkPolicy.customSelectors`   | Allow connectivity from pods that match a list of podSelectors and namespaceSelectors                                         | ``                                |
-
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-$ helm install --name my-release \
-  --set serviceAccount.name=pushgateway  \
-    stable/prometheus-pushgateway
-```
+# Helm 2
+$ helm inspect values prometheus-community/prometheus-pushgateway
 
-Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
-
-```console
-$ helm install --name my-release -f values.yaml stable/prometheus-pushgateway
+# Helm 3
+$ helm show values prometheus-community/prometheus-pushgateway
 ```

--- a/charts/prometheus-rabbitmq-exporter/Chart.yaml
+++ b/charts/prometheus-rabbitmq-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Rabbitmq metrics exporter for prometheus
 name: prometheus-rabbitmq-exporter
-version: 0.5.5
+version: 0.5.6
 appVersion: v0.29.0
 home: https://github.com/kbudde/rabbitmq_exporter
 sources:

--- a/charts/prometheus-rabbitmq-exporter/README.md
+++ b/charts/prometheus-rabbitmq-exporter/README.md
@@ -1,88 +1,73 @@
 # prometheus-rabbitmq-exporter
 
-[rabbitmq_exporter](https://github.com/kbudde/rabbitmq_exporter) is a Prometheus exporter for rabbitmq metrics.
+Prometheus Exporter for [RabbitMQ](https://www.rabbitmq.com/) metrics.
 
-## TL;DR;
-
-```bash
-$ helm install stable/prometheus-rabbitmq-exporter
-```
-
-## Introduction
-
-This chart bootstraps a [rabbitmq_exporter](https://github.com/kbudde/rabbitmq_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [RabbitMQ Exporter](https://github.com/kbudde/rabbitmq_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
 - Kubernetes 1.8+ with Beta APIs enabled
 
-## Installing the Chart
+## Get Repo Info
 
-To install the chart with the release name `my-release`:
-
-```bash
-$ helm install --name my-release stable/prometheus-rabbitmq-exporter
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo update
 ```
 
-The command deploys prometheus-rabbitmq-exporter on the Kubernetes cluster in the default configuration.
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-## Uninstalling the Chart
+## Install Chart
 
-To uninstall/delete the `my-release` deployment:
+```console
+# Helm 3
+$ helm install [RELEASE_NAME] prometheus-community/prometheus-rabbitmq-exporter
 
-```bash
-$ helm delete my-release
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-rabbitmq-exporter
 ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+_See [configuration](#configuration) below._
 
-## Configuration
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-The following table lists the configurable parameters and their default values.
+## Uninstall Chart
 
-| Parameter                | Description                                                            | Default                   |
-| ------------------------ | ---------------------------------------------------------------------- | ------------------------- |
-| `replicaCount`           | desired number of prometheus-rabbitmq-exporter pods                    | `1`                       |
-| `image.repository`       | prometheus-rabbitmq-exporter image repository                          | `kbudde/rabbitmq-exporter`|
-| `image.tag`              | prometheus-rabbitmq-exporter image tag                                 | `v0.29.0`                 |
-| `image.pullPolicy`       | image pull policy                                                      | `IfNotPresent`            |
-| `service.type`           | desired service type                                                   | `ClusterIP`               |
-| `service.internalport`   | service listening port                                                 | `9419`                    |
-| `service.externalPort`   | public service port                                                    | `9419`                    |
-| `resources`              | cpu/memory resource requests/limits                                    | {}                        |
-| `loglevel`               | exporter log level                                                     | {}                        |
-| `rabbitmq.url`           | rabbitmq management url                                                | `http://myrabbit:15672`   |
-| `rabbitmq.user`          | rabbitmq user login                                                    | `guest`                   |
-| `rabbitmq.password`      | rabbitmq password login                                                | `guest`                   |
-| `rabbitmq.existingPasswordSecret` | existing secret name containing password key                  | `~`                       |
-| `rabbitmq.capabilities`  | comma-separated list of capabilities supported by the RabbitMQ server  | `bert,no_sort`            |
-| `rabbitmq.include_queues`| regex queue filter. just matching names are exported                   | `.*`                      |
-| `rabbitmq.skip_queues`   | regex, matching queue names are not exported                           | `^$`                      |
-| `rabbitmq.include_vhost` | regex vhost filter. Only queues in matching vhosts are exported        | `.*`                      |
-| `rabbitmq.skip_vhost`    | regex, matching vhost names are not exported. First performs include_vhost, then skip_vhost | `^$` |
-| `rabbitmq.skip_verify`   | true/0 will ignore certificate errors of the management plugin         | `false`                   |
-| `rabbitmq.exporters`     | List of enabled modules. Just "connections" is not enabled by default  | `exchange,node,overview,queue` |
-| `rabbitmq.output_format` | Log ouput format. TTY and JSON are suported                            | `TTY`                     |
-| `rabbitmq.timeout`       | timeout in seconds for retrieving data from management plugin          | `30`                      |
-| `rabbitmq.max_queues`    | max number of queues before we drop metrics (disabled if set to 0)     | `0`                       |
-| `annotations`            | pod annotations for easier discovery                                   | {}                        |
-| `prometheus.monitor.enabled` | Set this to `true` to create ServiceMonitor for Prometheus operator | `false` |
-| `prometheus.monitor.additionalLabels` | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | {} |
-| `prometheus.monitor.interval` | Interval at which Prometheus Operator scrapes exporter | `15s` |
-| `prometheus.monitor.namespace` | 	Selector to select which namespaces the Endpoints objects are discovered from. | [] |
+```console
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
 
-For more information please refer to the [rabbitmq_exporter](https://github.com/kbudde/rabbitmq_exporter) documentation.
-
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
-
-```bash
-$ helm install --name my-release \
-  --set "rabbitmq.url=http://myrabbit:15672" \
-    stable/prometheus-rabbitmq-exporter
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
 ```
 
-Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+This removes all the Kubernetes components associated with the chart and deletes the release.
 
-```bash
-$ helm install --name my-release -f values.yaml stable/prometheus-rabbitmq-exporter
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
 ```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+## Configuring
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+# Helm 2
+$ helm inspect values prometheus-community/prometheus-rabbitmq-exporter
+
+# Helm 3
+$ helm show values prometheus-community/prometheus-rabbitmq-exporter
+```
+
+### RabbitMQ Connection
+
+- To configure RabbitMQ connection by value, set `rabbitmq.url`, `rabbitmq.user` and `rabbitmq.password` (see additional options in the `rabbitmq` configuration block)
+- To configure RabbitMQ password by secret, you must store the password string in a secret, and set `rabbitmq.existingPasswordSecret` to `[SECRET_NAME]`

--- a/charts/prometheus-rabbitmq-exporter/README.md
+++ b/charts/prometheus-rabbitmq-exporter/README.md
@@ -12,7 +12,6 @@ This chart bootstraps a [RabbitMQ Exporter](https://github.com/kbudde/rabbitmq_e
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo update
 ```
 

--- a/charts/prometheus-redis-exporter/Chart.yaml
+++ b/charts/prometheus-redis-exporter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.3.4
 description: Prometheus exporter for Redis metrics
 name: prometheus-redis-exporter
-version: 3.5.0
+version: 3.5.1
 home: https://github.com/oliver006/redis_exporter
 sources:
   - https://github.com/oliver006/redis_exporter

--- a/charts/prometheus-redis-exporter/OWNERS
+++ b/charts/prometheus-redis-exporter/OWNERS
@@ -1,4 +1,0 @@
-approvers:
-- acondrat
-reviewers:
-- acondrat

--- a/charts/prometheus-redis-exporter/README.md
+++ b/charts/prometheus-redis-exporter/README.md
@@ -1,103 +1,88 @@
 # prometheus-redis-exporter
 
-[redis_exporter](https://github.com/oliver006/redis_exporter) is a Prometheus exporter for Redis metrics.
+Prometheus exporter for [Redis](https://redis.io/) metrics.
 
-## TL;DR;
-
-```bash
-$ helm install stable/prometheus-redis-exporter
-```
-
-## Introduction
-
-This chart bootstraps a [redis_exporter](https://github.com/oliver006/redis_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps a [Redis exporter](https://github.com/oliver006/redis_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
 - Kubernetes 1.10+ with Beta APIs enabled
 
-## Installing the Chart
+## Get Repo Info
 
-To install the chart with the release name `my-release`:
-
-```bash
-$ helm install --name my-release stable/prometheus-redis-exporter
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo update
 ```
 
-The command deploys prometheus-redis-exporter on the Kubernetes cluster in the default configuration.
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-## Uninstalling the Chart
+## Install Chart
 
-To uninstall/delete the `my-release` deployment:
+```console
+# Helm 3
+$ helm install [RELEASE_NAME] prometheus-community/prometheus-redis-exporter
 
-```bash
-$ helm delete my-release
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-redis-exporter
 ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+_See [configuration](#configuration) below._
 
-## Configuration
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
 
-The following table lists the configurable parameters and their default values.
+## Uninstall Chart
 
-| Parameter              | Description                                         | Default                   |
-| ---------------------- | --------------------------------------------------- | ------------------------- |
-| `replicaCount`         | desired number of prometheus-redis-exporter pods    | `1`                       |
-| `image.repository`     | prometheus-redis-exporter image repository          | `oliver006/redis_exporter`|
-| `image.tag`            | prometheus-redis-exporter image tag                 | `v1.3.4`                 |
-| `image.pullPolicy`     | image pull policy                                   | `IfNotPresent`            |
-| `image.pullSecrets`    | image pull secrets                                  | {}                        |
-| `extraArgs`            | extra arguments for the binary; possible values [here](https://github.com/oliver006/redis_exporter#flags)| {}
-| `env`                  | additional environment variables in YAML format. Can be used to pass credentials as env variables (via secret) as per the image readme [here](https://github.com/oliver006/redis_exporter#environment-variables) | {} |
-| `resources`            | cpu/memory resource requests/limits                 | {}                        |
-| `tolerations`          | toleration labels for pod assignment                | {}                        |
-| `affinity`             | affinity settings for pod assignment                | {}                        |
-| `service.type`         | desired service type                                | `ClusterIP`               |
-| `service.port`         | service external port                               | `9121`                    |
-| `service.annotations`  | Custom annotations for service                      | `{}`                      |
-| `service.labels`       | Additional custom labels for the service            | `{}`                      |
-| `redisAddress`         | Address of the Redis instance to scrape. Use `rediss://` for SSL.      | `redis://myredis:6379`    |
-| `annotations`          | pod annotations for easier discovery                | {}                        |
-| `rbac.create`           | Specifies whether RBAC resources should be created.| `true` |
-| `rbac.pspEnabled`       | Specifies whether a PodSecurityPolicy should be created.| `true` |
-| `serviceAccount.create` | Specifies whether a service account should be created.| `true` |
-| `serviceAccount.name`   | Name of the service account.|        |
-| `serviceMonitor.enabled`       | Use servicemonitor from prometheus operator            | `false`                    |
-| `serviceMonitor.namespace`     | Namespace this servicemonitor is installed in          |                            |
-| `serviceMonitor.interval`      | How frequently Prometheus should scrape                |                            |
-| `serviceMonitor.telemetryPath` | Path to redis-exporter telemtery-path                  |                            |
-| `serviceMonitor.labels`        | Labels for the servicemonitor passed to Prometheus Operator      |  `{}`            |
-| `serviceMonitor.timeout`       | Timeout after which the scrape is ended                |                            |
-| `serviceMonitor.targetLabels`  | Set of labels to transfer on the Kubernetes Service onto the target.  |             |
-| `serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion.  |             |
-| `prometheusRule.enabled`           | Set this to true to create prometheusRules for Prometheus operator | `false`     |
-| `prometheusRule.additionalLabels`  | Additional labels that can be used so prometheusRules will be discovered by Prometheus  | `{}`  |
-| `prometheusRule.namespace`         | namespace where prometheusRules resource should be created |      |
-| `prometheusRule.rules`             | [rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) to be created, check values for an example.                      | `[]`                                                    |
-| `script.configmap`     | Let you run a custom lua script from a configmap. The corresponding environment variable `REDIS_EXPORTER_SCRIPT` will be set automatically ||
-| `script.keyname`       | Name of the key inside configmap which contains your script ||
-| `auth.enabled`       | Specifies whether redis uses authentication | `false` |
-| `auth.secret.name`       | Name of existing redis secret (ignores redisPassword) ||
-| `auth.secret.key`       | Name of key containing password to be retrieved from the existing secret ||
-| `auth.redisPassword`       | Redis password (when not stored in a secret) ||
+```console
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+### To 3.0.1
+
+ The default tag for the exporter image is now `v1.x.x`. This major release includes changes to the names of various metrics and no longer directly supports the configuration (and scraping) of multiple redis instances; that is now the Prometheus server's responsibility. You'll want to use [this dashboard](https://github.com/oliver006/redis_exporter/blob/master/contrib/grafana_prometheus_redis_dashboard.json) now. Please see the [redis_exporter github page](https://github.com/oliver006/redis_exporter#upgrading-from-0x-to-1x) for more details.
+
+## Configuring
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
+
+```console
+# Helm 2
+$ helm inspect values prometheus-community/prometheus-redis-exporter
+
+# Helm 3
+$ helm show values prometheus-community/prometheus-redis-exporter
+```
 
 For more information please refer to the [redis_exporter](https://github.com/oliver006/redis_exporter) documentation.
 
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+### Redis Connection
 
-```bash
-$ helm install --name my-release \
-  --set "redisAddress=redis://myredis:6379" \
-    stable/prometheus-redis-exporter
-```
+- To configure RabbitMQ connection set `redisAddress` string (example format: `redis://myredis:6379`)
+- To configure auth by value, set `auth.enabled` to `true`, and `auth.redisPassword` value
+- To configure auth by secret, set `auth.secret.name` and `auth.secret.key` values
 
-Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
-
-```bash
-$ helm install --name my-release -f values.yaml stable/prometheus-redis-exporter
-```
 ### Using a custom LUA-Script
+
 First, you need to deploy the script with a configmap. This is an example script from mentioned in the [redis_exporter-image repository](https://github.com/oliver006/redis_exporter/blob/master/contrib/sample_collect_script.lua)
+
 ```yaml
 apiVersion: v1
 kind: ConfigMap
@@ -127,10 +112,5 @@ data:
 
     return result
 ```
+
 If you want to use this script for collecting metrics, you could do this by just set `script.configmap` to the name of the configmap (e.g. `prometheus-redis-exporter-script`) and `script.keyname` to the configmap-key holding the script (eg. `script`). The required variables inside the container will be set automatically.
-
-## Upgrading
-
-### To 3.0.1
-
- The default tag for the exporter image is now `v1.x.x`. This major release includes changes to the names of various metrics and no longer directly supports the configuration (and scraping) of multiple redis instances; that is now the Prometheus server's responsibility. You'll want to use [this dashboard](https://github.com/oliver006/redis_exporter/blob/master/contrib/grafana_prometheus_redis_dashboard.json) now. Please see the [redis_exporter github page](https://github.com/oliver006/redis_exporter#upgrading-from-0x-to-1x) for more details.

--- a/charts/prometheus-redis-exporter/README.md
+++ b/charts/prometheus-redis-exporter/README.md
@@ -12,7 +12,6 @@ This chart bootstraps a [Redis exporter](https://github.com/oliver006/redis_expo
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo update
 ```
 

--- a/charts/prometheus-snmp-exporter/Chart.yaml
+++ b/charts/prometheus-snmp-exporter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Prometheus SNMP Exporter
 name: prometheus-snmp-exporter
-version: 0.0.5
+version: 0.0.6
 appVersion: 0.14.0
 home: https://github.com/prometheus/snmp_exporter
 sources:

--- a/charts/prometheus-snmp-exporter/OWNERS
+++ b/charts/prometheus-snmp-exporter/OWNERS
@@ -1,4 +1,0 @@
-approvers:
-- miouge1
-reviewers:
-- miouge1

--- a/charts/prometheus-snmp-exporter/README.md
+++ b/charts/prometheus-snmp-exporter/README.md
@@ -12,7 +12,6 @@ This chart creates a [SNMP Exporter](https://github.com/prometheus/snmp_exporter
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo update
 ```
 

--- a/charts/prometheus-snmp-exporter/README.md
+++ b/charts/prometheus-snmp-exporter/README.md
@@ -1,109 +1,81 @@
 # Prometheus SNMP Exporter
 
-Prometheus exporter for snmp monitoring
+An Prometheus exporter that exposes information gathered from SNMP.
 
-Learn more: [https://github.com/prometheus/snmp_exporter](https://github.com/prometheus/snmp_exporter)
-
-## TL;DR;
-
-```bash
-$ helm install stable/prometheus-snmp-exporter
-```
-
-## Introduction
-
-This chart creates a SNMP-Exporter deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart creates a [SNMP Exporter](https://github.com/prometheus/snmp_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
 - Kubernetes 1.8+ with Beta APIs enabled
 
-## Installing the Chart
+## Get Repo Info
 
-To install the chart with the release name `my-release`:
-
-```bash
-$ helm install --name my-release stable/prometheus-snmp-exporter
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo update
 ```
 
-The command deploys SNMP Exporter on the Kubernetes cluster using the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-## Uninstalling the Chart
+## Install Chart
 
-To uninstall/delete the `my-release` deployment:
+```console
+# Helm 3
+$ helm install [RELEASE_NAME] prometheus-community/prometheus-snmp-exporter
 
-```bash
-$ helm delete --purge my-release
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-snmp-exporter
 ```
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
 ## Configuration
 
-The following table lists the configurable parameters of the SNMP-Exporter chart and their default values.
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
-|               Parameter                |                   Description                   |            Default            |
-| -------------------------------------- | ----------------------------------------------- | ----------------------------- |
-| `config`                               | Prometheus SNMP configuration                   | {}                            |
-| `configmapReload.name`                 | configmap-reload container name                 | `configmap-reload`            |
-| `configmapReload.image.repository`     | configmap-reload container image repository     | `jimmidyson/configmap-reload` |
-| `configmapReload.image.tag`            | configmap-reload container image tag            | `v0.2.2`                      |
-| `configmapReload.image.pullPolicy`     | configmap-reload container image pull policy    | `IfNotPresent`                |
-| `configmapReload.extraArgs`            | Additional configmap-reload container arguments | `{}`                          |
-| `configmapReload.extraConfigmapMounts` | Additional configmap-reload configMap mounts    | `[]`                          |
-| `configmapReload.resources`            | configmap-reload pod resource requests & limits | `{}`                          |
-| `extraArgs`                            | Optional flags for exporter                     | `[]`                          |
-| `image.repository`                     | container image repository                      | `prom/snmp-exporter`          |
-| `image.tag`                            | container image tag                             | `v0.12.0`                     |
-| `image.pullPolicy`                     | container image pull policy                     | `IfNotPresent`                |
-| `ingress.annotations`                  | Ingress annotations                             | None                          |
-| `ingress.enabled`                      | Enables Ingress                                 | `false`                       |
-| `ingress.hosts`                        | Ingress accepted hostnames                      | None                          |
-| `ingress.tls`                          | Ingress TLS configuration                       | None                          |
-| `nodeSelector`                         | node labels for pod assignment                  | `{}`                          |
-| `tolerations`                          | node tolerations for pod assignment             | `[]`                          |
-| `affinity`                             | node affinity for pod assignment                | `{}`                          |
-| `podAnnotations`                       | annotations to add to each pod                  | `{}`                          |
-| `resources`                            | pod resource requests & limits                  | `{}`                          |
-| `restartPolicy`                        | container restart policy                        | `Always`                      |
-| `service.annotations`                  | annotations for the service                     | `{}`                          |
-| `service.labels`                       | additional labels for the service               | None                          |
-| `service.type`                         | type of service to create                       | `ClusterIP`                   |
-| `service.port`                         | port for the snmp http service                  | `9116`                        |
-| `service.externalIPs`                  | list of external ips                            | []                            |
-| `rbac.create`                          | Use Role-based Access Control                   | `true`                        |
-| `serviceAccount.create`                | Should we create a ServiceAccount               | `true`                        |
-| `serviceAccount.name`                  | Name of the ServiceAccount to use               | `null`                        |
-| `serviceMonitor.enabled`               | Enables ServiceMonitor                          | `false`                       |
-| `serviceMonitor.params.enabled`        | Enables params for serviceMonitor               | `false`                       |
-| `serviceMonitor.params.conf.module`    | Module to use for scrapes                       | `[]`                          |
-| `serviceMonitor.params.conf.target`    | List of target(s) to scrape                     | `[]`                          |
+```console
+# Helm 2
+$ helm inspect values prometheus-community/prometheus-snmp-exporter
 
-
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
-
-```bash
-$ helm install --name my-release \
-    --set key_1=value_1,key_2=value_2 \
-    stable/prometheus-snmp-exporter
+# Helm 3
+$ helm show values prometheus-community/prometheus-snmp-exporter
 ```
 
-Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+See [prometheus/snmp_exporter/README.md](https://github.com/prometheus/snmp_exporter/) for further information.
 
-```bash
-# example for staging
-$ helm install --name my-release -f values.yaml stable/prometheus-snmp-exporter
-```
-
-> **Tip**: You can use the default [values.yaml](values.yaml)
-
-## Prometheus Configuration
-
+### Prometheus Configuration
 
 The snmp exporter needs to be passed the address as a parameter, this can be done with relabelling.
 
 Example config:
 
-```
+```yaml
 scrape_configs:
   - job_name: 'snmp'
     static_configs:
@@ -120,5 +92,3 @@ scrape_configs:
       - target_label: __address__
         replacement: my-service-name:9116  # The SNMP exporter's Service name and port.
 ```
-
-See [prometheus/snmp_exporter/README.md](https://github.com/prometheus/snmp_exporter/) for further information.

--- a/charts/prometheus-to-sd/Chart.yaml
+++ b/charts/prometheus-to-sd/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 - name: acondrat
   email: arcadie.condrat@gmail.com
 name: prometheus-to-sd
-version: 0.3.0
+version: 0.3.1

--- a/charts/prometheus-to-sd/OWNERS
+++ b/charts/prometheus-to-sd/OWNERS
@@ -1,4 +1,0 @@
-approvers:
-- acondrat
-reviewers:
-- acondrat

--- a/charts/prometheus-to-sd/README.md
+++ b/charts/prometheus-to-sd/README.md
@@ -11,7 +11,6 @@
 
 ```console
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 helm repo update
 ```
 

--- a/charts/prometheus-to-sd/README.md
+++ b/charts/prometheus-to-sd/README.md
@@ -2,67 +2,72 @@
 
 [prometheus-to-sd](https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/prometheus-to-sd) is a simple component that can scrape metrics stored in prometheus text format from one or multiple components and push them to the Stackdriver
 
-## TL;DR;
-
-```bash
-$ helm install stable/prometheus-to-sd
-```
-
-
 ## Prerequisites
 
 - a service exposing metrics in prometheus format
 - k8s cluster should run on GCE or GKE
 
-## Installing the Chart
+## Get Repo Info
 
-To install the chart with the release name `my-release`:
-
-```bash
-$ helm install --name my-release stable/prometheus-to-sd
+```console
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo update
 ```
 
-The command deploys prometheus-to-sd on the Kubernetes cluster in the default configuration.
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-## Uninstalling the Chart
+## Install Chart
 
-To uninstall/delete the `my-release` deployment:
+```console
+# Helm 3
+$ helm install [RELEASE_NAME] prometheus-community/prometheus-to-sd
 
-```bash
-$ helm delete my-release
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/prometheus-to-sd
 ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Uninstall Chart
+
+```console
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
+
+## Upgrading Chart
+
+```console
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
 
 ## Configuration
 
-The following table lists the configurable parameters and their default values.
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
-| Parameter          | Description                                                                               | Default                                                    |
-| ------------------ | ----------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| `image.repository` | prometheus-to-sd image repository                                                         | `gcr.io/google-containers/prometheus-to-sd`                |
-| `image.tag`        | prometheus-to-sd image tag                                                                | `v0.5.2`                                                   |
-| `image.pullPolicy` | Image pull policy                                                                         | `IfNotPresent`                                             |
-| `resources`        | CPU/Memory resource requests/limits                                                       | `{}`                                                       |
-| `port`             | Profiler port                                                                             | `6060`                                                     |
-| `metricSources`    | Sources for metrics in the next format: component-name:http://host:port?whitelisted=a,b,c | `{"kube-state-metrics": "http://kube-state-metrics:8080"}` |
-| `nodeSelector`     | node labels for pod assignment                                                            | `{}`                                                       |
-| `tolerations`      | tolerations for node taints                                                               | `[]`                                                       |
+```console
+# Helm 2
+$ helm inspect values prometheus-community/prometheus-to-sd
+
+# Helm 3
+$ helm show values prometheus-community/prometheus-to-sd
+```
 
 For more information please refer to the [prometheus-to-sd](https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/prometheus-to-sd) documentation.
 
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+### Metrics Sources
 
-```bash
-$ helm install --name my-release \
-  --set "metricsSources.kube-state-metrics=http://kube-state-metrics:8080" \
-    stable/prometheus-to-sd
-```
-
-Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
-
-```bash
-$ helm install --name my-release -f values.yaml stable/prometheus-to-sd
-```
-
-Multiple metrics sources can be defined.
+Multiple metrics sources can be defined. To configure, set `metricsSources` value (example: `http://kube-state-metrics:8080`)

--- a/charts/prometheus-to-sd/templates/deployment.yaml
+++ b/charts/prometheus-to-sd/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "prometheus-to-sd.fullname" . }}

--- a/charts/prometheus-to-sd/templates/deployment.yaml
+++ b/charts/prometheus-to-sd/templates/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus-to-sd.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: prometheus
-version: 11.11.1
-appVersion: 2.19.0
+version: 11.12.0
+appVersion: 2.20.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/
 icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png

--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: prometheus
-version: 11.12.0
+version: 11.12.1
 appVersion: 2.20.1
 description: Prometheus is a monitoring system and time series database.
 home: https://prometheus.io/

--- a/charts/prometheus/OWNERS
+++ b/charts/prometheus/OWNERS
@@ -1,8 +1,0 @@
-approvers:
-- gianrubio
-- zanhsieh
-- Xtigyro
-reviewers:
-- gianrubio
-- zanhsieh
-- Xtigyro

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -185,7 +185,7 @@ Parameter | Description | Default
 `configmapReload.prometheus.enabled` | If false, the configmap-reload container for Prometheus will not be deployed | `true`
 `configmapReload.prometheus.name` | configmap-reload container name | `configmap-reload`
 `configmapReload.prometheus.image.repository` | configmap-reload container image repository | `jimmidyson/configmap-reload`
-`configmapReload.prometheus.image.tag` | configmap-reload container image tag | `v0.3.0`
+`configmapReload.prometheus.image.tag` | configmap-reload container image tag | `v0.4.0`
 `configmapReload.prometheus.image.pullPolicy` | configmap-reload container image pull policy | `IfNotPresent`
 `configmapReload.prometheus.extraArgs` | Additional configmap-reload container arguments | `{}`
 `configmapReload.prometheus.extraVolumeDirs` | Additional configmap-reload volume directories | `{}`
@@ -194,7 +194,7 @@ Parameter | Description | Default
 `configmapReload.alertmanager.enabled` | If false, the configmap-reload container for AlertManager will not be deployed | `true`
 `configmapReload.alertmanager.name` | configmap-reload container name | `configmap-reload`
 `configmapReload.alertmanager.image.repository` | configmap-reload container image repository | `jimmidyson/configmap-reload`
-`configmapReload.alertmanager.image.tag` | configmap-reload container image tag | `v0.3.0`
+`configmapReload.alertmanager.image.tag` | configmap-reload container image tag | `v0.4.0`
 `configmapReload.alertmanager.image.pullPolicy` | configmap-reload container image pull policy | `IfNotPresent`
 `configmapReload.alertmanager.extraArgs` | Additional configmap-reload container arguments | `{}`
 `configmapReload.alertmanager.extraVolumeDirs` | Additional configmap-reload volume directories | `{}`
@@ -282,7 +282,7 @@ Parameter | Description | Default
 `server.enabled` | If false, Prometheus server will not be created | `true`
 `server.name` | Prometheus server container name | `server`
 `server.image.repository` | Prometheus server container image repository | `prom/prometheus`
-`server.image.tag` | Prometheus server container image tag | `v2.19.0`
+`server.image.tag` | Prometheus server container image tag | `v2.20.1`
 `server.image.pullPolicy` | Prometheus server container image pull policy | `IfNotPresent`
 `server.configPath` |  Path to a prometheus server config file on the container FS  | `/etc/config/prometheus.yml`
 `server.global.scrape_interval` | How frequently to scrape targets by default | `1m`

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -2,49 +2,67 @@
 
 [Prometheus](https://prometheus.io/), a [Cloud Native Computing Foundation](https://cncf.io/) project, is a systems and service monitoring system. It collects metrics from configured targets at given intervals, evaluates rule expressions, displays the results, and can trigger alerts if some condition is observed to be true.
 
-## TL;DR;
-
-```console
-helm install stable/prometheus
-```
-
-## Introduction
-
 This chart bootstraps a [Prometheus](https://prometheus.io/) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Prerequisites
 
 - Kubernetes 1.3+ with Beta APIs enabled
 
-## Installing the Chart
-
-To install the chart with the release name `my-release`:
+## Get Repo Info
 
 ```console
-helm install --name my-release stable/prometheus
+$ helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+$ helm repo update
 ```
 
-The command deploys Prometheus on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+_See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
 
-> **Tip**: List all releases using `helm list`
-
-## Uninstalling the Chart
-
-To uninstall/delete the `my-release` deployment:
+## Install Chart
 
 ```console
-helm delete my-release
+# Helm 2
+$ helm install prometheus-community/prometheus
+
+# Helm 3
+$ helm install prometheus-community/prometheus --generate-name
 ```
 
-The command removes all the Kubernetes components associated with the chart and deletes the release.
+_See [configuration](#configuration) below._
+
+_See [helm install](https://helm.sh/docs/helm/helm_install/) for command documentation._
+
+## Dependencies
+
+By default this chart installs additional, dependent charts:
+
+- [stable/kube-state-metrics](https://github.com/helm/charts/tree/master/stable/kube-state-metrics)
+
+To disable the dependency during installation, set `kubeStateMetrics.enabled` to `false`.
+
+_See [helm dependency](https://helm.sh/docs/helm/helm_dependency/) for command documentation._
+
+## Uninstall Chart
+
+```console
+# Helm 2
+# help delete --purge [RELEASE_NAME]
+
+# Helm 3
+$ helm uninstall [RELEASE_NAME]
+```
+
+This removes all the Kubernetes components associated with the chart and deletes the release.
+
+_See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
 ## Prometheus 2.x
 
-Prometheus version 2.x has made changes to alertmanager, storage and recording rules. Check out the migration guide [here](https://prometheus.io/docs/prometheus/2.0/migration/)
+Prometheus version 2.x has made changes to alertmanager, storage and recording rules. Check out the migration guide [here](https://prometheus.io/docs/prometheus/2.0/migration/).
 
 Users of this chart will need to update their alerting rules to the new format before they can upgrade.
 
-## Upgrading from previous chart versions.
+## Upgrading Chart
 
 Version 9.0 adds a new option to enable or disable the Prometheus Server.
 This supports the use case of running a Prometheus server in one k8s cluster and scraping exporters in another cluster while using the same chart for each deployment.
@@ -52,7 +70,7 @@ To install the server `server.enabled` must be set to `true`.
 
 As of version 5.0, this chart uses Prometheus 2.x. This version of prometheus introduces a new data format and is not compatible with prometheus 1.x. It is recommended to install this as a new release, as updating existing releases will not work. See the [prometheus docs](https://prometheus.io/docs/prometheus/latest/migration/#storage) for instructions on retaining your old data.
 
-### Example migration
+### Example Migration
 
 Assuming you have an existing release of the prometheus chart, named `prometheus-old`. In order to update to prometheus 2.x while keeping your old data do the following:
 
@@ -90,16 +108,23 @@ Assuming you have an existing release of the prometheus chart, named `prometheus
 
    Old data will be available when you query the new prometheus instance.
 
+## Configuration
+
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments:
+
+```console
+# Helm 2
+$ helm inspect values prometheus-community/prometheus
+
+# Helm 3
+$ helm show values prometheus-community/prometheus
+```
+
+You may similarly use the above configuration commands on each chart [dependency](#dependencies) to see it's configurations.
+
 ## Scraping Pod Metrics via Annotations
 
-This chart uses a default configuration that causes prometheus
-to scrape a variety of kubernetes resource types, provided they have the correct annotations.
-In this section we describe how to configure pods to be scraped;
-for information on how other resource types can be scraped you can
-do a `helm template` to get the kubernetes resource definitions,
-and then reference the prometheus configuration in the ConfigMap against the prometheus documentation
-for [relabel_config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config)
-and [kubernetes_sd_config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config).
+This chart uses a default configuration that causes prometheus to scrape a variety of kubernetes resource types, provided they have the correct annotations. In this section we describe how to configure pods to be scraped; for information on how other resource types can be scraped you can do a `helm template` to get the kubernetes resource definitions, and then reference the prometheus configuration in the ConfigMap against the prometheus documentation for [relabel_config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) and [kubernetes_sd_config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config).
 
 In order to get prometheus to scrape pods, you must add annotations to the the pods as below:
 
@@ -109,307 +134,11 @@ metadata:
     prometheus.io/scrape: "true"
     prometheus.io/path: /metrics
     prometheus.io/port: "8080"
-spec:
-...
 ```
 
-You should adjust `prometheus.io/path` based on the URL that your pod serves metrics from.
-`prometheus.io/port` should be set to the port that your pod serves metrics from.
-Note that the values for `prometheus.io/scrape` and `prometheus.io/port` must be
-enclosed in double quotes.
+You should adjust `prometheus.io/path` based on the URL that your pod serves metrics from. `prometheus.io/port` should be set to the port that your pod serves metrics from. Note that the values for `prometheus.io/scrape` and `prometheus.io/port` must be enclosed in double quotes.
 
-## Configuration
-
-The following table lists the configurable parameters of the Prometheus chart and their default values.
-
-Parameter | Description | Default
---------- | ----------- | -------
-`alertmanager.enabled` | If true, create alertmanager | `true`
-`alertmanager.name` | alertmanager container name | `alertmanager`
-`alertmanager.useClusterRole` | Use a ClusterRole (and ClusterRoleBinding). If set to false - we define a Role and RoleBinding in the defined namespaces ONLY. This makes alertmanager work - for users who do not have ClusterAdmin privs, but wants alertmanager to operate on their own namespaces, instead of clusterwide. | `alertmanager`
-`alertmanager.useExistingRole` | Set to a rolename to use existing role - skipping role creating - but still doing serviceaccount and rolebinding to the rolename set here.  | `alertmanager`
-`alertmanager.image.repository` | alertmanager container image repository | `prom/alertmanager`
-`alertmanager.image.tag` | alertmanager container image tag | `v0.21.0`
-`alertmanager.image.pullPolicy` | alertmanager container image pull policy | `IfNotPresent`
-`alertmanager.prefixURL` | The prefix slug at which the server can be accessed | ``
-`alertmanager.baseURL` | The external url at which the server can be accessed | `"http://localhost:9093"`
-`alertmanager.extraArgs` | Additional alertmanager container arguments | `{}`
-`alertmanager.extraSecretMounts` | Additional alertmanager Secret mounts | `[]`
-`alertmanager.configMapOverrideName` | Prometheus alertmanager ConfigMap override where full-name is `{{.Release.Name}}-{{.Values.alertmanager.configMapOverrideName}}` and setting this value will prevent the default alertmanager ConfigMap from being generated | `""`
-`alertmanager.configFromSecret` | The name of a secret in the same kubernetes namespace which contains the Alertmanager config, setting this value will prevent the default alertmanager ConfigMap from being generated | `""`
-`alertmanager.configFileName` | The configuration file name to be loaded to alertmanager. Must match the key within configuration loaded from ConfigMap/Secret. | `alertmanager.yml`
-`alertmanager.ingress.enabled` | If true, alertmanager Ingress will be created | `false`
-`alertmanager.ingress.annotations` | alertmanager Ingress annotations | `{}`
-`alertmanager.ingress.extraLabels` | alertmanager Ingress additional labels | `{}`
-`alertmanager.ingress.hosts` | alertmanager Ingress hostnames | `[]`
-`alertmanager.ingress.extraPaths` | Ingress extra paths to prepend to every alertmanager host configuration. Useful when configuring [custom actions with AWS ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions) | `[]`
-`alertmanager.ingress.tls` | alertmanager Ingress TLS configuration (YAML) | `[]`
-`alertmanager.nodeSelector` | node labels for alertmanager pod assignment | `{}`
-`alertmanager.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
-`alertmanager.affinity` | pod affinity | `{}`
-`alertmanager.podDisruptionBudget.enabled` | If true, create a PodDisruptionBudget | `false`
-`alertmanager.podDisruptionBudget.maxUnavailable` | Maximum unavailable instances in PDB | `1`
-`alertmanager.schedulerName` | alertmanager alternate scheduler name | `nil`
-`alertmanager.persistentVolume.enabled` | If true, alertmanager will create a Persistent Volume Claim | `true`
-`alertmanager.persistentVolume.accessModes` | alertmanager data Persistent Volume access modes | `[ReadWriteOnce]`
-`alertmanager.persistentVolume.annotations` | Annotations for alertmanager Persistent Volume Claim | `{}`
-`alertmanager.persistentVolume.existingClaim` | alertmanager data Persistent Volume existing claim name | `""`
-`alertmanager.persistentVolume.mountPath` | alertmanager data Persistent Volume mount root path | `/data`
-`alertmanager.persistentVolume.size` | alertmanager data Persistent Volume size | `2Gi`
-`alertmanager.persistentVolume.storageClass` | alertmanager data Persistent Volume Storage Class | `unset`
-`alertmanager.persistentVolume.volumeBindingMode` | alertmanager data Persistent Volume Binding Mode | `unset`
-`alertmanager.persistentVolume.subPath` | Subdirectory of alertmanager data Persistent Volume to mount | `""`
-`alertmanager.podAnnotations` | annotations to be added to alertmanager pods | `{}`
-`alertmanager.podLabels` | labels to be added to Prometheus AlertManager pods | `{}`
-`alertmanager.podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}` |
-`alertmanager.replicaCount` | desired number of alertmanager pods | `1`
-`alertmanager.statefulSet.enabled` | If true, use a statefulset instead of a deployment for pod management | `false`
-`alertmanager.statefulSet.podManagementPolicy` | podManagementPolicy of alertmanager pods | `OrderedReady`
-`alertmanager.statefulSet.headless.annotations` | annotations for alertmanager headless service | `{}`
-`alertmanager.statefulSet.headless.labels` | labels for alertmanager headless service | `{}`
-`alertmanager.statefulSet.headless.enableMeshPeer` | If true, enable the mesh peer endpoint for the headless service | `false`
-`alertmanager.statefulSet.headless.servicePort` | alertmanager headless service port | `80`
-`alertmanager.priorityClassName` | alertmanager priorityClassName | `nil`
-`alertmanager.resources` | alertmanager pod resource requests & limits | `{}`
-`alertmanager.securityContext` | Custom [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for Alert Manager containers | `{}`
-`alertmanager.service.annotations` | annotations for alertmanager service | `{}`
-`alertmanager.service.clusterIP` | internal alertmanager cluster service IP | `""`
-`alertmanager.service.externalIPs` | alertmanager service external IP addresses | `[]`
-`alertmanager.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
-`alertmanager.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
-`alertmanager.service.servicePort` | alertmanager service port | `80`
-`alertmanager.service.sessionAffinity` | Session Affinity for alertmanager service, can be `None` or `ClientIP` | `None`
-`alertmanager.service.type` | type of alertmanager service to create | `ClusterIP`
-`alertmanager.strategy` | Deployment strategy | `{ "type": "RollingUpdate" }`
-`alertmanagerFiles.alertmanager.yml` | Prometheus alertmanager configuration | example configuration
-`configmapReload.prometheus.enabled` | If false, the configmap-reload container for Prometheus will not be deployed | `true`
-`configmapReload.prometheus.name` | configmap-reload container name | `configmap-reload`
-`configmapReload.prometheus.image.repository` | configmap-reload container image repository | `jimmidyson/configmap-reload`
-`configmapReload.prometheus.image.tag` | configmap-reload container image tag | `v0.4.0`
-`configmapReload.prometheus.image.pullPolicy` | configmap-reload container image pull policy | `IfNotPresent`
-`configmapReload.prometheus.extraArgs` | Additional configmap-reload container arguments | `{}`
-`configmapReload.prometheus.extraVolumeDirs` | Additional configmap-reload volume directories | `{}`
-`configmapReload.prometheus.extraConfigmapMounts` | Additional configmap-reload configMap mounts | `[]`
-`configmapReload.prometheus.resources` | configmap-reload pod resource requests & limits | `{}`
-`configmapReload.alertmanager.enabled` | If false, the configmap-reload container for AlertManager will not be deployed | `true`
-`configmapReload.alertmanager.name` | configmap-reload container name | `configmap-reload`
-`configmapReload.alertmanager.image.repository` | configmap-reload container image repository | `jimmidyson/configmap-reload`
-`configmapReload.alertmanager.image.tag` | configmap-reload container image tag | `v0.4.0`
-`configmapReload.alertmanager.image.pullPolicy` | configmap-reload container image pull policy | `IfNotPresent`
-`configmapReload.alertmanager.extraArgs` | Additional configmap-reload container arguments | `{}`
-`configmapReload.alertmanager.extraVolumeDirs` | Additional configmap-reload volume directories | `{}`
-`configmapReload.alertmanager.extraConfigmapMounts` | Additional configmap-reload configMap mounts | `[]`
-`configmapReload.alertmanager.resources` | configmap-reload pod resource requests & limits | `{}`
-`initChownData.enabled`  | If false, don't reset data ownership at startup | true
-`initChownData.name` | init-chown-data container name | `init-chown-data`
-`initChownData.image.repository` | init-chown-data container image repository | `busybox`
-`initChownData.image.tag` | init-chown-data container image tag | `latest`
-`initChownData.image.pullPolicy` | init-chown-data container image pull policy | `IfNotPresent`
-`initChownData.resources` | init-chown-data pod resource requests & limits | `{}`
-`kubeStateMetrics.enabled` | If true, create kube-state-metrics sub-chart, see the [kube-state-metrics chart for configuration options](https://github.com/helm/charts/tree/master/stable/kube-state-metrics) | `true`
-`kube-state-metrics` | [kube-state-metrics configuration options](https://github.com/helm/charts/tree/master/stable/kube-state-metrics) | `Same as sub-chart's`
-`nodeExporter.enabled` | If true, create node-exporter | `true`
-`nodeExporter.name` | node-exporter container name | `node-exporter`
-`nodeExporter.image.repository` | node-exporter container image repository| `prom/node-exporter`
-`nodeExporter.image.tag` | node-exporter container image tag | `v1.0.1`
-`nodeExporter.image.pullPolicy` | node-exporter container image pull policy | `IfNotPresent`
-`nodeExporter.extraArgs` | Additional node-exporter container arguments | `{}`
-`nodeExporter.extraInitContainers` | Init containers to launch alongside the node-exporter | `[]`
-`nodeExporter.extraHostPathMounts` | Additional node-exporter hostPath mounts | `[]`
-`nodeExporter.extraConfigmapMounts` | Additional node-exporter configMap mounts | `[]`
-`nodeExporter.hostNetwork` | If true, node-exporter pods share the host network namespace | `true`
-`nodeExporter.hostPID` | If true, node-exporter pods share the host PID namespace | `true`
-`nodeExporter.nodeSelector` | node labels for node-exporter pod assignment | `{}`
-`nodeExporter.podAnnotations` | annotations to be added to node-exporter pods | `{}`
-`nodeExporter.pod.labels` | labels to be added to node-exporter pods | `{}`
-`nodeExporter.podDisruptionBudget.enabled` | If true, create a PodDisruptionBudget | `false`
-`nodeExporter.podDisruptionBudget.maxUnavailable` | Maximum unavailable instances in PDB | `1`
-`nodeExporter.podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}` |
-`nodeExporter.podSecurityPolicy.enabled` | Specify if a Pod Security Policy for node-exporter must be created | `false`
-`nodeExporter.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
-`nodeExporter.priorityClassName` | node-exporter priorityClassName | `nil`
-`nodeExporter.resources` | node-exporter resource requests and limits (YAML) | `{}`
-`nodeExporter.securityContext` | securityContext for containers in pod | `{}`
-`nodeExporter.service.annotations` | annotations for node-exporter service | `{prometheus.io/scrape: "true"}`
-`nodeExporter.service.clusterIP` | internal node-exporter cluster service IP | `None`
-`nodeExporter.service.externalIPs` | node-exporter service external IP addresses | `[]`
-`nodeExporter.service.hostPort` | node-exporter service host port | `9100`
-`nodeExporter.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
-`nodeExporter.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
-`nodeExporter.service.servicePort` | node-exporter service port | `9100`
-`nodeExporter.service.type` | type of node-exporter service to create | `ClusterIP`
-`podSecurityPolicy.enabled` | If true, create & use pod security policies resources | `false`
-`pushgateway.enabled` | If true, create pushgateway | `true`
-`pushgateway.name` | pushgateway container name | `pushgateway`
-`pushgateway.image.repository` | pushgateway container image repository | `prom/pushgateway`
-`pushgateway.image.tag` | pushgateway container image tag | `v1.2.0`
-`pushgateway.image.pullPolicy` | pushgateway container image pull policy | `IfNotPresent`
-`pushgateway.extraArgs` | Additional pushgateway container arguments | `{}`
-`pushgateway.extraInitContainers` | Init containers to launch alongside the pushgateway | `[]`
-`pushgateway.ingress.enabled` | If true, pushgateway Ingress will be created | `false`
-`pushgateway.ingress.annotations` | pushgateway Ingress annotations | `{}`
-`pushgateway.ingress.hosts` | pushgateway Ingress hostnames | `[]`
-`pushgateway.ingress.extraPaths` | Ingress extra paths to prepend to every pushgateway host configuration. Useful when configuring [custom actions with AWS ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions) | `[]`
-`pushgateway.ingress.tls` | pushgateway Ingress TLS configuration (YAML) | `[]`
-`pushgateway.nodeSelector` | node labels for pushgateway pod assignment | `{}`
-`pushgateway.podAnnotations` | annotations to be added to pushgateway pods | `{}`
-`pushgateway.podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}` |
-`pushgateway.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
-`pushgateway.replicaCount` | desired number of pushgateway pods | `1`
-`pushgateway.podDisruptionBudget.enabled` | If true, create a PodDisruptionBudget | `false`
-`pushgateway.podDisruptionBudget.maxUnavailable` | Maximum unavailable instances in PDB | `1`
-`pushgateway.schedulerName` | pushgateway alternate scheduler name | `nil`
-`pushgateway.persistentVolume.enabled` | If true, Prometheus pushgateway will create a Persistent Volume Claim | `false`
-`pushgateway.persistentVolume.accessModes` | Prometheus pushgateway data Persistent Volume access modes | `[ReadWriteOnce]`
-`pushgateway.persistentVolume.annotations` | Prometheus pushgateway data Persistent Volume annotations | `{}`
-`pushgateway.persistentVolume.existingClaim` | Prometheus pushgateway data Persistent Volume existing claim name | `""`
-`pushgateway.persistentVolume.mountPath` | Prometheus pushgateway data Persistent Volume mount root path | `/data`
-`pushgateway.persistentVolume.size` | Prometheus pushgateway data Persistent Volume size | `2Gi`
-`pushgateway.persistentVolume.storageClass` | Prometheus pushgateway data Persistent Volume Storage Class |  `unset`
-`pushgateway.persistentVolume.volumeBindingMode` | Prometheus pushgateway data Persistent Volume Binding Mode |  `unset`
-`pushgateway.persistentVolume.subPath` | Subdirectory of Prometheus server data Persistent Volume to mount | `""`
-`pushgateway.priorityClassName` | pushgateway priorityClassName | `nil`
-`pushgateway.resources` | pushgateway pod resource requests & limits | `{}`
-`pushgateway.service.annotations` | annotations for pushgateway service | `{}`
-`pushgateway.service.clusterIP` | internal pushgateway cluster service IP | `""`
-`pushgateway.service.externalIPs` | pushgateway service external IP addresses | `[]`
-`pushgateway.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
-`pushgateway.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
-`pushgateway.service.servicePort` | pushgateway service port | `9091`
-`pushgateway.service.type` | type of pushgateway service to create | `ClusterIP`
-`pushgateway.strategy` | Deployment strategy | `{ "type": "RollingUpdate" }`
-`rbac.create` | If true, create & use RBAC resources | `true`
-`server.enabled` | If false, Prometheus server will not be created | `true`
-`server.name` | Prometheus server container name | `server`
-`server.image.repository` | Prometheus server container image repository | `prom/prometheus`
-`server.image.tag` | Prometheus server container image tag | `v2.20.1`
-`server.image.pullPolicy` | Prometheus server container image pull policy | `IfNotPresent`
-`server.configPath` |  Path to a prometheus server config file on the container FS  | `/etc/config/prometheus.yml`
-`server.global.scrape_interval` | How frequently to scrape targets by default | `1m`
-`server.global.scrape_timeout` | How long until a scrape request times out | `10s`
-`server.global.evaluation_interval` | How frequently to evaluate rules | `1m`
-`server.remoteWrite` | The remote write feature of Prometheus allow transparently sending samples. | `[]`
-`server.remoteRead` | The remote read feature of Prometheus allow transparently receiving samples. | `[]`
-`server.extraArgs` | Additional Prometheus server container arguments | `{}`
-`server.extraFlags` | Additional Prometheus server container flags | `["web.enable-lifecycle"]`
-`server.extraInitContainers` | Init containers to launch alongside the server | `[]`
-`server.prefixURL` | The prefix slug at which the server can be accessed |``
-`server.baseURL` | The external url at which the server can be accessed | ``
-`server.env` | Prometheus server environment variables | `[]`
-`server.extraHostPathMounts` | Additional Prometheus server hostPath mounts | `[]`
-`server.extraConfigmapMounts` | Additional Prometheus server configMap mounts | `[]`
-`server.extraSecretMounts` | Additional Prometheus server Secret mounts | `[]`
-`server.extraVolumeMounts` | Additional Prometheus server Volume mounts | `[]`
-`server.extraVolumes` | Additional Prometheus server Volumes | `[]`
-`server.configMapOverrideName` | Prometheus server ConfigMap override where full-name is `{{.Release.Name}}-{{.Values.server.configMapOverrideName}}` and setting this value will prevent the default server ConfigMap from being generated | `""`
-`server.ingress.enabled` | If true, Prometheus server Ingress will be created | `false`
-`server.ingress.annotations` | Prometheus server Ingress annotations | `[]`
-`server.ingress.extraLabels` | Prometheus server Ingress additional labels | `{}`
-`server.ingress.hosts` | Prometheus server Ingress hostnames | `[]`
-`server.ingress.extraPaths` | Ingress extra paths to prepend to every Prometheus server host configuration. Useful when configuring [custom actions with AWS ALB Ingress Controller](https://kubernetes-sigs.github.io/aws-alb-ingress-controller/guide/ingress/annotation/#actions) | `[]`
-`server.ingress.tls` | Prometheus server Ingress TLS configuration (YAML) | `[]`
-`server.nodeSelector` | node labels for Prometheus server pod assignment | `{}`
-`server.tolerations` | node taints to tolerate (requires Kubernetes >=1.6) | `[]`
-`server.affinity` | pod affinity | `{}`
-`server.podDisruptionBudget.enabled` | If true, create a PodDisruptionBudget | `false`
-`server.podDisruptionBudget.maxUnavailable` | Maximum unavailable instances in PDB | `1`
-`server.priorityClassName` | Prometheus server priorityClassName | `nil`
-`server.enableServiceLinks` | Set service environment variables in Prometheus server pods | `true`
-`server.schedulerName` | Prometheus server alternate scheduler name | `nil`
-`server.persistentVolume.enabled` | If true, Prometheus server will create a Persistent Volume Claim | `true`
-`server.persistentVolume.accessModes` | Prometheus server data Persistent Volume access modes | `[ReadWriteOnce]`
-`server.persistentVolume.annotations` | Prometheus server data Persistent Volume annotations | `{}`
-`server.persistentVolume.existingClaim` | Prometheus server data Persistent Volume existing claim name | `""`
-`server.persistentVolume.mountPath` | Prometheus server data Persistent Volume mount root path | `/data`
-`server.persistentVolume.size` | Prometheus server data Persistent Volume size | `8Gi`
-`server.persistentVolume.storageClass` | Prometheus server data Persistent Volume Storage Class |  `unset`
-`server.persistentVolume.volumeBindingMode` | Prometheus server data Persistent Volume Binding Mode | `unset`
-`server.persistentVolume.subPath` | Subdirectory of Prometheus server data Persistent Volume to mount | `""`
-`server.emptyDir.sizeLimit` | emptyDir sizeLimit if a Persistent Volume is not used | `""`
-`server.podAnnotations` | annotations to be added to Prometheus server pods | `{}`
-`server.podLabels` | labels to be added to Prometheus server pods | `{}`
-`server.alertmanagers` | Prometheus AlertManager configuration for the Prometheus server | `{}`
-`server.deploymentAnnotations` | annotations to be added to Prometheus server deployment | `{}`
-`server.podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}` |
-`server.replicaCount` | desired number of Prometheus server pods | `1`
-`server.statefulSet.enabled` | If true, use a statefulset instead of a deployment for pod management | `false`
-`server.statefulSet.annotations` | annotations to be added to Prometheus server stateful set | `{}`
-`server.statefulSet.labels` | labels to be added to Prometheus server stateful set | `{}`
-`server.statefulSet.podManagementPolicy` | podManagementPolicy of server pods | `OrderedReady`
-`server.statefulSet.headless.annotations` | annotations for Prometheus server headless service | `{}`
-`server.statefulSet.headless.labels` | labels for Prometheus server headless service | `{}`
-`server.statefulSet.headless.servicePort` | Prometheus server headless service port | `80`
-`server.statefulSet.headless.gRPC.enabled` | If true, open a second port on the service for gRPC | `false`
-`server.statefulSet.headless.gRPC.servicePort` | Prometheus service gRPC port, (ignored if `server.service.gRPC.enabled` is not `true`) | `10901`
-`server.statefulSet.headless.gRPC.nodePort` | Port to be used as gRPC nodePort in the prometheus service | `0`
-`server.readinessProbeInitialDelay` | the initial delay for the Prometheus server readiness probe | `30`
-`server.readinessProbePeriodSeconds` | how often (in seconds) to perform the Prometheus server readiness probe | `5`
-`server.readinessProbeTimeout` | the timeout for the Prometheus server readiness probe | `30`
-`server.readinessProbeFailureThreshold` | the failure threshold for the Prometheus server readiness probe | `3`
-`server.readinessProbeSuccessThreshold` | the success threshold for the Prometheus server readiness probe | `1`
-`server.livenessProbeInitialDelay` | the initial delay for the Prometheus server liveness probe | `30`
-`server.livenessProbePeriodSeconds` | how often (in seconds) to perform the Prometheus server liveness probe | `15`
-`server.livenessProbeTimeout` | the timeout for the Prometheus server liveness probe  | `30`
-`server.livenessProbeFailureThreshold` | the failure threshold for the Prometheus server liveness probe | `3`
-`server.livenessProbeSuccessThreshold` | the success threshold for the Prometheus server liveness probe | `1`
-`server.resources` | Prometheus server resource requests and limits | `{}`
-`server.verticalAutoscaler.enabled` | If true a VPA object will be created for the controller (either StatefulSet or Deployemnt, based on above configs) | `false`
-`server.securityContext` | Custom [security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) for server containers | `{}`
-`server.service.annotations` | annotations for Prometheus server service | `{}`
-`server.service.clusterIP` | internal Prometheus server cluster service IP | `""`
-`server.service.externalIPs` | Prometheus server service external IP addresses | `[]`
-`server.service.loadBalancerIP` | IP address to assign to load balancer (if supported) | `""`
-`server.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`
-`server.service.nodePort` | Port to be used as the service NodePort (ignored if `server.service.type` is not `NodePort`) | `0`
-`server.service.servicePort` | Prometheus server service port | `80`
-`server.service.sessionAffinity` | Session Affinity for server service, can be `None` or `ClientIP` | `None`
-`server.service.type` | type of Prometheus server service to create | `ClusterIP`
-`server.service.gRPC.enabled` | If true, open a second port on the service for gRPC | `false`
-`server.service.gRPC.servicePort` | Prometheus service gRPC port, (ignored if `server.service.gRPC.enabled` is not `true`) | `10901`
-`server.service.gRPC.nodePort` | Port to be used as gRPC nodePort in the prometheus service | `0`
-`server.service.statefulsetReplica.enabled` | If true, send the traffic from the service to only one replica of the replicaset | `false`
-`server.service.statefulsetReplica.replica` | Which replica to send the traffice to | `0`
-`server.hostAliases` | /etc/hosts-entries in container(s) | []
-`server.sidecarContainers` | array of snippets with your sidecar containers for prometheus server | `""`
-`server.strategy` | Deployment strategy | `{ "type": "RollingUpdate" }`
-`serviceAccounts.alertmanager.create` | If true, create the alertmanager service account | `true`
-`serviceAccounts.alertmanager.name` | name of the alertmanager service account to use or create | `{{ prometheus.alertmanager.fullname }}`
-`serviceAccounts.alertmanager.annotations` | annotations for the alertmanager service account | `{}`
-`serviceAccounts.nodeExporter.create` | If true, create the nodeExporter service account | `true`
-`serviceAccounts.nodeExporter.name` | name of the nodeExporter service account to use or create | `{{ prometheus.nodeExporter.fullname }}`
-`serviceAccounts.nodeExporter.annotations` | annotations for the nodeExporter service account | `{}`
-`serviceAccounts.pushgateway.create` | If true, create the pushgateway service account | `true`
-`serviceAccounts.pushgateway.name` | name of the pushgateway service account to use or create | `{{ prometheus.pushgateway.fullname }}`
-`serviceAccounts.pushgateway.annotations` | annotations for the pushgateway service account | `{}`
-`serviceAccounts.server.create` | If true, create the server service account | `true`
-`serviceAccounts.server.name` | name of the server service account to use or create | `{{ prometheus.server.fullname }}`
-`serviceAccounts.server.annotations` | annotations for the server service account | `{}`
-`server.terminationGracePeriodSeconds` | Prometheus server Pod termination grace period | `300`
-`server.retention` | (optional) Prometheus data retention | `"15d"`
-`serverFiles.alerts` | (Deprecated) Prometheus server alerts configuration | `{}`
-`serverFiles.rules` | (Deprecated) Prometheus server rules configuration | `{}`
-`serverFiles.alerting_rules.yml` | Prometheus server alerts configuration | `{}`
-`serverFiles.recording_rules.yml` | Prometheus server rules configuration | `{}`
-`serverFiles.prometheus.yml` | Prometheus server scrape configuration | example configuration
-`extraScrapeConfigs` | Prometheus server additional scrape configuration | ""
-`alertRelabelConfigs` | Prometheus server [alert relabeling configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alert_relabel_configs) for H/A prometheus | ""
-`networkPolicy.enabled` | Enable NetworkPolicy | `false`
-`forceNamespace` | Force resources to be namespaced | `null` |
-
-Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
-
-```console
-helm install stable/prometheus --name my-release \
-    --set server.terminationGracePeriodSeconds=360
-```
-
-Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
-
-```console
-helm install stable/prometheus --name my-release -f values.yaml
-```
-
-> **Tip**: You can use the default [values.yaml](values.yaml)
+### Sharing Alerts Between Services
 
 Note that you have multiple yaml files. This is particularly useful when you have alerts belonging to multiple services in the cluster. For example,
 
@@ -433,7 +162,7 @@ serverFiles:
 ```
 
 ```console
-helm install stable/prometheus --name my-release -f values.yaml -f service1-alert.yaml -f service2-alert.yaml
+$ helm install -f values.yaml -f service1-alert.yaml -f service2-alert.yaml ...etc
 ```
 
 ### RBAC Configuration
@@ -452,7 +181,7 @@ Prometheus is configured through [prometheus.yml](https://prometheus.io/docs/ope
 
 ### Ingress TLS
 
-If your cluster allows automatic creation/retrieval of TLS certificates (e.g. [kube-lego](https://github.com/jetstack/kube-lego)), please refer to the documentation for that mechanism.
+If your cluster allows automatic creation/retrieval of TLS certificates (e.g. [cert-manager](https://github.com/jetstack/cert-manager)), please refer to the documentation for that mechanism.
 
 To manually configure TLS, first create/retrieve a key & certificate pair for the address(es) you wish to protect. Then create a TLS secret in the namespace:
 
@@ -486,12 +215,8 @@ server:
 
 ### NetworkPolicy
 
-Enabling Network Policy for Prometheus will secure connections to Alert Manager
-and Kube State Metrics by only accepting connections from Prometheus Server.
-All inbound connections to Prometheus Server are still allowed.
+Enabling Network Policy for Prometheus will secure connections to Alert Manager and Kube State Metrics by only accepting connections from Prometheus Server. All inbound connections to Prometheus Server are still allowed.
 
-To enable network policy for Prometheus, install a networking plugin that
-implements the Kubernetes NetworkPolicy spec, and set `networkPolicy.enabled` to true.
+To enable network policy for Prometheus, install a networking plugin that implements the Kubernetes NetworkPolicy spec, and set `networkPolicy.enabled` to true.
 
-If NetworkPolicy is enabled for Prometheus' scrape targets, you may also need
-to manually create a networkpolicy which allows it.
+If NetworkPolicy is enabled for Prometheus' scrape targets, you may also need to manually create a networkpolicy which allows it.

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -129,7 +129,7 @@ $ helm show values prometheus-community/prometheus
 
 You may similarly use the above configuration commands on each chart [dependency](#dependencies) to see it's configurations.
 
-## Scraping Pod Metrics via Annotations
+### Scraping Pod Metrics via Annotations
 
 This chart uses a default configuration that causes prometheus to scrape a variety of kubernetes resource types, provided they have the correct annotations. In this section we describe how to configure pods to be scraped; for information on how other resource types can be scraped you can do a `helm template` to get the kubernetes resource definitions, and then reference the prometheus configuration in the ConfigMap against the prometheus documentation for [relabel_config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config) and [kubernetes_sd_config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config).
 

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -11,9 +11,9 @@ This chart bootstraps a [Prometheus](https://prometheus.io/) deployment on a [Ku
 ## Get Repo Info
 
 ```console
-$ helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-$ helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-$ helm repo update
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+helm repo update
 ```
 
 _See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation._
@@ -169,7 +169,7 @@ serverFiles:
 ```
 
 ```console
-$ helm install -f values.yaml -f service1-alert.yaml -f service2-alert.yaml ...etc
+helm install -f values.yaml -f service1-alert.yaml -f service2-alert.yaml ...etc
 ```
 
 ### RBAC Configuration

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -117,7 +117,7 @@ Assuming you have an existing release of the prometheus chart, named `prometheus
 
 ## Configuration
 
-See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments:
+See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
 # Helm 2

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -147,7 +147,7 @@ You should adjust `prometheus.io/path` based on the URL that your pod serves met
 
 ### Sharing Alerts Between Services
 
-Note that you have multiple yaml files. This is particularly useful when you have alerts belonging to multiple services in the cluster. For example,
+Note that when [installing](#install-chart) or [upgrading](#upgrading-chart) you may use multiple values override files. This is particularly useful when you have alerts belonging to multiple services in the cluster. For example,
 
 ```yaml
 # values.yaml
@@ -169,7 +169,7 @@ serverFiles:
 ```
 
 ```console
-helm install -f values.yaml -f service1-alert.yaml -f service2-alert.yaml ...etc
+helm install [RELEASE_NAME] prometheus-community/prometheus -f values.yaml -f service1-alert.yaml -f service2-alert.yaml
 ```
 
 ### RBAC Configuration

--- a/charts/prometheus/README.md
+++ b/charts/prometheus/README.md
@@ -21,11 +21,11 @@ _See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation
 ## Install Chart
 
 ```console
-# Helm 2
-$ helm install prometheus-community/prometheus
-
 # Helm 3
-$ helm install prometheus-community/prometheus --generate-name
+$ helm install [RELEASE_NAME] prometheus-community/prometheus
+
+# Helm 2
+$ helm install --name [RELEASE_NAME] prometheus-community/prometheus
 ```
 
 _See [configuration](#configuration) below._
@@ -45,30 +45,37 @@ _See [helm dependency](https://helm.sh/docs/helm/helm_dependency/) for command d
 ## Uninstall Chart
 
 ```console
-# Helm 2
-# help delete --purge [RELEASE_NAME]
-
 # Helm 3
 $ helm uninstall [RELEASE_NAME]
+
+# Helm 2
+# helm delete --purge [RELEASE_NAME]
 ```
 
 This removes all the Kubernetes components associated with the chart and deletes the release.
 
 _See [helm uninstall](https://helm.sh/docs/helm/helm_uninstall/) for command documentation._
 
-## Prometheus 2.x
+## Upgrading Chart
+
+```console
+# Helm 3 or 2
+$ helm upgrade [RELEASE_NAME] [CHART] --install
+```
+
+_See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documentation._
+
+### To 9.0
+
+Version 9.0 adds a new option to enable or disable the Prometheus Server. This supports the use case of running a Prometheus server in one k8s cluster and scraping exporters in another cluster while using the same chart for each deployment. To install the server `server.enabled` must be set to `true`.
+
+### To 5.0
+
+As of version 5.0, this chart uses Prometheus 2.x. This version of prometheus introduces a new data format and is not compatible with prometheus 1.x. It is recommended to install this as a new release, as updating existing releases will not work. See the [prometheus docs](https://prometheus.io/docs/prometheus/latest/migration/#storage) for instructions on retaining your old data.
 
 Prometheus version 2.x has made changes to alertmanager, storage and recording rules. Check out the migration guide [here](https://prometheus.io/docs/prometheus/2.0/migration/).
 
 Users of this chart will need to update their alerting rules to the new format before they can upgrade.
-
-## Upgrading Chart
-
-Version 9.0 adds a new option to enable or disable the Prometheus Server.
-This supports the use case of running a Prometheus server in one k8s cluster and scraping exporters in another cluster while using the same chart for each deployment.
-To install the server `server.enabled` must be set to `true`.
-
-As of version 5.0, this chart uses Prometheus 2.x. This version of prometheus introduces a new data format and is not compatible with prometheus 1.x. It is recommended to install this as a new release, as updating existing releases will not work. See the [prometheus docs](https://prometheus.io/docs/prometheus/latest/migration/#storage) for instructions on retaining your old data.
 
 ### Example Migration
 

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -332,7 +332,7 @@ configmapReload:
     ##
     image:
       repository: jimmidyson/configmap-reload
-      tag: v0.3.0
+      tag: v0.4.0
       pullPolicy: IfNotPresent
 
     ## Additional configmap-reload container arguments
@@ -370,7 +370,7 @@ configmapReload:
     ##
     image:
       repository: jimmidyson/configmap-reload
-      tag: v0.3.0
+      tag: v0.4.0
       pullPolicy: IfNotPresent
 
     ## Additional configmap-reload container arguments
@@ -568,7 +568,7 @@ server:
   ##
   image:
     repository: prom/prometheus
-    tag: v2.19.2
+    tag: v2.20.1
     pullPolicy: IfNotPresent
 
   ## prometheus server priorityClassName

--- a/ct.yaml
+++ b/ct.yaml
@@ -6,3 +6,5 @@ chart-dirs:
 chart-repos:
   - stable=https://kubernetes-charts.storage.googleapis.com/
 helm-extra-args: --timeout 600s
+# Temporary workaround for https://github.com/scottrigby/prometheus-helm-charts/pull/14#issuecomment-677488920
+validate-maintainers: false

--- a/ct.yaml
+++ b/ct.yaml
@@ -6,5 +6,6 @@ chart-dirs:
 chart-repos:
   - stable=https://kubernetes-charts.storage.googleapis.com/
 helm-extra-args: --timeout 600s
-# Temporary workaround for https://github.com/scottrigby/prometheus-helm-charts/pull/14#issuecomment-677488920
-validate-maintainers: false
+excluded-charts:
+  # If not running on GCE, will error: "Failed to get GCE config"
+  - prometheus-to-sd


### PR DESCRIPTION
Fixes #7, Fixes #8

- [x] Cherry-pick commits from the one PR that was merged since the code was copied https://github.com/helm/charts/pull/23506 (see #13 for context)
- [x] Deprecate charts/prometheus-operator (see #8 and #9 for context)
- [x] Remove prow `OWNERS` files (see #12 for context)

Charts that need to be prepared for initial helm index
- [x] charts/prometheus
- [x] charts/prometheus-adapter
- [x] charts/prometheus-blackbox-exporter
- [x] charts/prometheus-cloudwatch-exporter
- [x] charts/prometheus-consul-exporter
- [x] charts/prometheus-couchdb-exporter
- [x] charts/prometheus-mongodb-exporter
- [x] charts/prometheus-mysql-exporter
- [x] charts/prometheus-nats-exporter
- [x] charts/prometheus-node-exporter
- [x] charts/prometheus-postgres-exporter
- [x] charts/prometheus-pushgateway
- [x] charts/prometheus-rabbitmq-exporter
- [x] charts/prometheus-redis-exporter
- [x] charts/prometheus-snmp-exporter
- [x] charts/prometheus-to-sd

**Suggestion:** per the steps in the plan at https://github.com/prometheus-community/community/issues/28#issuecomment-670230344 (which has been approved for the prometheus-community), for this PR review and comments let's discuss only what should happen in the intial step. To be clear, this PR is the first step, before "Step 2. Collaborate with prometheus devs to refactor/rename and simplify charts as appropriate." I outlined what I think we need in #7, but please let me know if I'm missing anything.

## 📊  Maintainers poll
How do you all feel about the new `charts/prometheus` README update in b324685? I Needed to update references to stable repo, but took the opportunity to reorganize, fix and simplify. Is this a good pattern for the other chart READMEs? Note major differences are:
- Added Helm 2 and Helm 3 commands, with links to Helm 3 command reference links (from there, users can select Helm 2 from the version dropdown if they wish)
- Removed the options table that's duplicated from (often out of sync with) `values.yaml` in favor of `helm inspect` (Helm 2) and `helm show values` (Helm 3)

**Results:** new template has been approved by all who responded