### PR TITLE
Add configuration for Stale GitHub app

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,16 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 30
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - lifecycle/frozen
+staleLabel: lifecycle/stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Any further update will
+  cause the issue/pull request to no longer be considered stale. Thank you for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue is being automatically closed due to inactivity.


### PR DESCRIPTION
This adds a configuration for https://github.com/apps/stale. If you want to use it then this should be merged and afterwards the GitHub installed to the repository.

Config is taken from https://github.com/helm/charts/blob/92be1ddfc5a242eacae8c34a4401eb1561240d74/.github/stale.yml