### PR TITLE
fix errors reported by superlinter

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,5 +16,10 @@ jobs:
         uses: github/super-linter@v3
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_BASH: false
+          VALIDATE_PYTHON: false
+          VALIDATE_PYTHON_FLAKE8: false
+          VALIDATE_PYTHON_BLACK: false
+          VALIDATE_YAML: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
-## Community Code of Conduct
+# Community Code of Conduct
 
 Prometheus follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Contributions are welcome via GitHub pull requests. This document outlines the p
 
 The Developer Certificate of Origin (DCO) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project. Here is the full text of the [DCO](http://developercertificate.org/). Contributors must sign-off that they adhere to these requirements by adding a `Signed-off-by` line to commit messages.
 
-```
+```text
 This is my commit message
 
 Signed-off-by: Random J Developer <random@developer.example.org>
@@ -14,7 +14,7 @@ Signed-off-by: Random J Developer <random@developer.example.org>
 
 See `git help commit`:
 
-```
+```text
 -s, --signoff
     Add Signed-off-by line by the committer at the end of the commit log
     message. The meaning of a signoff depends on the project, but it typically

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 Once Helm is set up properly, add the repo as follows:
 
 ```console
-$ helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 ```
 
 You can then run `helm search repo prometheus-community` to see the charts.

--- a/charts/kube-prometheus/hack/minikube/README.md
+++ b/charts/kube-prometheus/hack/minikube/README.md
@@ -1,3 +1,5 @@
+# Testing on Minikube
+
 The configuration in this folder lets you locally test the setup on minikube. Use cmd.sh to set up components and hack a working etcd scrape configuration. Run the commands in the sequence listed in the script to get a local working minikube cluster.
 
 If you're using windows, there's a commented-out section that you should add to the minikube command.


### PR DESCRIPTION
The goal of this is to resolve all errors reported by superlinter or to disable the linters which report errors.
That way we would not block contributions. Disabled linters can be enabled one by one in separate PRs if desired together with fixing issues reported by them.